### PR TITLE
Fix maven complaining no version declared on maven-jar-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
         <configuration>
           <archive>
             <manifest>


### PR DESCRIPTION
It stopped maven from complaining when building the project.
I used the latest version of maven-jar-plugin.

```

$mvn package         
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for PokeGoBot:PokeGoBot:jar:0.0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 42, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```
