### PR TITLE
Fix for confirmation dialog when evolving

### DIFF
--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -359,8 +359,8 @@ public class PokemonTab extends JPanel {
 					+ (Math.round(p.getIvRatio() * 10000) / 100) + "%";
 			switch (operation){
 				case "Evolve":
-					str += " Cost: " + p.getCandyCostsForPowerup();
-					str += p.getCandyCostsForPowerup()>1?" Candies":" Candy";
+					str += " Cost: " + p.getCandiesToEvolve();
+					str += p.getCandiesToEvolve()>1?" Candies":" Candy";
 					break;
 				case "PowerUp":
 					str += " Cost: " + p.getCandyCostsForPowerup();


### PR DESCRIPTION
The confirmation dialog for clicking the Evolve button was displaying the candy cost to power up instead of the candy cost to evolve.
