### PR TITLE
Delay on bulk operations

### DIFF
--- a/src/me/corriekay/pokegoutil/utils/Utilities.java
+++ b/src/me/corriekay/pokegoutil/utils/Utilities.java
@@ -19,6 +19,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import javax.imageio.ImageIO;
 import javax.swing.JOptionPane;
@@ -257,10 +258,22 @@ public abstract class Utilities {
         return c;
     }
 
-    public static void sleep(int sleep) {
+    public static void sleep(long milliseconds) {
         try {
-            Thread.sleep(sleep);
-        } catch (Exception e) {
+            TimeUnit.MILLISECONDS.sleep(milliseconds);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void sleepRandom(int minMilliseconds, int maxMilliseconds) {
+        int from = Math.min(minMilliseconds, maxMilliseconds);
+        int to = Math.max(minMilliseconds, maxMilliseconds);
+        try {
+            int randomInt = random.nextInt((from - to) + 1) + to;
+            System.out.println("Waiting " + (randomInt / 1000.0F) + " seconds.");
+            TimeUnit.MILLISECONDS.sleep(randomInt);
+        } catch (InterruptedException e) {
             e.printStackTrace();
         }
     }

--- a/src/me/corriekay/pokegoutil/utils/Utilities.java
+++ b/src/me/corriekay/pokegoutil/utils/Utilities.java
@@ -29,247 +29,250 @@ import org.apache.commons.lang3.StringUtils;
 import com.pokegoapi.api.player.Team;
 
 public abstract class Utilities {
-	private static final Random random = new Random(System.currentTimeMillis());
-	
-	private Utilities() {}
-	
-	public static void setNativeLookAndFeel() {
-		try {
-			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-		} catch (Exception e) {}
-	}
-	
-	public static void deleteFile(File file, boolean deleteDir) {
-		if (file.isDirectory()) {
-			for (File subFile : file.listFiles()) {
-				deleteFile(subFile, true);
-			}
-			if (deleteDir) {
-				file.delete();
-			}
-		} else {
-			file.delete();
-		}
-	}
-	
-	public static boolean checkFilename(String checkme, boolean warn) {
-		String[] chars = new String[] { "\\", "/", ":", "*", "?", "\"", "<", ">", "|" };
-		
-		for (String c : chars) {
-			
-			if (checkme.contains(c)) {
-				if (warn) JOptionPane.showMessageDialog(null, "A file name can't contain any of the following characters: \\/:*\"<>|");
-				return false;
-			}
-		}
-		return true;
-	}
-	
-	public static boolean checkFileExists(File file) {
-		if (file.exists()) {
-			JOptionPane.showMessageDialog(null, "This file already exists. Please choose another file name.");
-			return true;
-		}
-		return false;
-	}
-	
-	public static Image loadImage(String filename) {
-		
-		try {
-			return ImageIO.read(Utilities.class.getClassLoader().getResourceAsStream(filename));
-		} catch (Exception e) {
-			System.out.println("UNABLE TO READ IMAGE " + filename);
-			return null;
-		}
-	}
-	
-	public static String readResourceFile(String res) {
-		try {
-			InputStream is = Utilities.class.getClassLoader().getResourceAsStream(res);
-			BufferedReader in = new BufferedReader(new InputStreamReader(is));
-			StringBuilder sb = new StringBuilder();
-			in.lines().forEach(s -> sb.append(s + "\n"));
-			in.close();
-			return sb.toString();
-		} catch (Exception e) {
-			//e.printStackTrace();
-			return null;
-		}
-	}
-	
-	public static String readFile(String url) {
-		return readFile(new File(url));
-	}
-	
-	public static String readFile(File file) {
-		try {
-			BufferedReader in = new BufferedReader(new FileReader(file));
-			
-			StringBuilder sb = new StringBuilder();
-			
-			String l = "";
-			boolean firstline = true;
-			do {
-				sb.append(l);
-				l = in.readLine();
-				if (l != null && !firstline) {
-					sb.append("\n");
-					firstline = false;
-				}
-			} while (l != null);
-			in.close();
-			return sb.toString();
-		} catch (Exception e) {
-			e.printStackTrace(); //TODO tagging for future exception handling/logging
-		}
-		return null;
-	}
-	
-	public static void saveFile(File file, String saveme) {
-		try {
-			file.createNewFile();
-			BufferedWriter out = new BufferedWriter(new FileWriter(file));
-			out.write(saveme);
-			out.close();
-		} catch (Exception e) {
-			System.out.println("Exception caught trying to save file. Path: " + file.getAbsolutePath());
-			e.printStackTrace(); //TODO tagging for future exception handling/logging
-		}
-	}
-	
-	public static String joinStringArray(String[] args) {
-		return joinStringArray(args, "");
-	}
-	
-	public static String joinArrayList(ArrayList<String> args) {
-		return joinArrayList(args, "");
-	}
-	
-	public static String joinStringSet(Set<String> args) {
-		return joinStringSet(args, "");
-	}
-	
-	public static String joinStringArray(String[] args, String delimiter) {
-		return joinStringArray(args, delimiter, 0);
-	}
-	
-	public static String joinArrayList(ArrayList<String> args, String delimiter) {
-		return joinArrayList(args, delimiter, 0);
-	}
-	
-	public static String joinStringSet(Set<String> args, String delimiter) {
-		return joinStringSet(args, delimiter, 0);
-	}
-	
-	public static String joinStringArray(String[] args, String delimiter, int startingIndex) {
-		StringBuilder s = new StringBuilder();
-		for (int i = startingIndex; i < args.length; i++) {
-			s.append(args[i]);
-			if (!(i + 1 >= args.length)) {
-				s.append(delimiter);
-			}
-		}
-		return s.toString();
-	}
-	
-	public static String joinArrayList(ArrayList<String> args, String delimiter, int startingIndex) {
-		StringBuilder s = new StringBuilder();
-		for (int i = startingIndex; i < args.size(); i++) {
-			s.append(args.get(i));
-			if (!(i + 1 >= args.size())) {
-				s.append(delimiter);
-			}
-		}
-		return s.toString();
-	}
-	
-	public static String joinStringSet(Set<String> args, String delimiter, int startingIndex) {
-		int count = startingIndex;
-		StringBuilder s = new StringBuilder();
-		for (String string : args) {
-			if (count >= startingIndex) {
-				s.append(string);
-				if (count + 1 < args.size()) {
-					s.append(delimiter);
-				}
-			}
-			count++;
-		}
-		return s.toString();
-	}
-	
-	public static String getStringFromIndex(int index, String[] args) {
-		String s = "";
-		for (int i = index; i < args.length; i++) {
-			s += args[i] + " ";
-		}
-		return s.trim();
-	}
-	
-	public static void setLocationMidScreen(Window frame, int screen) {
-		frame.setLocation(getLocationMidScreen(frame, screen));
-	}
+    private static final Random random = new Random(System.currentTimeMillis());
 
-	public static void setLocationMidScreen(Window frame) {
-		setLocationMidScreen(frame, 0);
-	}
-	
-	public static Point getLocationMidScreen(Window frame, int screen) {
-		DisplayMode monitor = GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices()[screen]
-				.getDisplayMode();
-		Point p = new Point(monitor.getWidth() / 2 - (frame.getWidth() / 2),
-				monitor.getHeight() / 2 - (frame.getHeight() / 2));
+    private Utilities() {
+    }
 
-		return p;
-	}
+    public static void setNativeLookAndFeel() {
+        try {
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        } catch (Exception e) {
+        }
+    }
 
-	public static Point getLocationMidScreen(Window frame) {
-		return getLocationMidScreen(frame, 0);
-	}
-	
-	public static String getTimeStamp(String format) {
-		return getTimeStamp(format, System.currentTimeMillis());
-	}
-	
-	public static String getTimeStamp(String format, long time) {
-		return new SimpleDateFormat(format).format(time);
-	}
-	
-	public static boolean isEven(long i) {
-		return i % 2 == 0;
-	}
-	
-	public static void setBackgroundColorRecursively(Container container, Color color) {
-		for (int i = 0; i < container.getComponentCount(); i++) {
-			Component component = container.getComponent(i);
-			if (component instanceof Container) {
-				setBackgroundColorRecursively((Container) component, color);
-			}
-			component.setBackground(color);
-		}
-	}
-	
-	public static Color randomColor() {
-		Color c = new Color(random.nextInt(255), random.nextInt(255), random.nextInt(255), 255);
-		return c;
-	}
-	
-	public static void sleep(int sleep) {
-		try {
-			Thread.sleep(sleep);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-	}
-	
-	public static String convertTeamColorToName(int teamValue){
-		Team[] teams = Team.values();
-		
-		for(Team team : teams){
-			if(team.getValue() == teamValue){
-				return StringUtils.capitalize(team.toString().toLowerCase().replaceAll("team_", ""));
-			}
-		}
-		return "UNKNOWN_TEAM";
-	}
+    public static void deleteFile(File file, boolean deleteDir) {
+        if (file.isDirectory()) {
+            for (File subFile : file.listFiles()) {
+                deleteFile(subFile, true);
+            }
+            if (deleteDir) {
+                file.delete();
+            }
+        } else {
+            file.delete();
+        }
+    }
+
+    public static boolean checkFilename(String checkme, boolean warn) {
+        String[] chars = new String[]{"\\", "/", ":", "*", "?", "\"", "<", ">", "|"};
+
+        for (String c : chars) {
+
+            if (checkme.contains(c)) {
+                if (warn)
+                    JOptionPane.showMessageDialog(null, "A file name can't contain any of the following characters: \\/:*\"<>|");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean checkFileExists(File file) {
+        if (file.exists()) {
+            JOptionPane.showMessageDialog(null, "This file already exists. Please choose another file name.");
+            return true;
+        }
+        return false;
+    }
+
+    public static Image loadImage(String filename) {
+
+        try {
+            return ImageIO.read(Utilities.class.getClassLoader().getResourceAsStream(filename));
+        } catch (Exception e) {
+            System.out.println("UNABLE TO READ IMAGE " + filename);
+            return null;
+        }
+    }
+
+    public static String readResourceFile(String res) {
+        try {
+            InputStream is = Utilities.class.getClassLoader().getResourceAsStream(res);
+            BufferedReader in = new BufferedReader(new InputStreamReader(is));
+            StringBuilder sb = new StringBuilder();
+            in.lines().forEach(s -> sb.append(s + "\n"));
+            in.close();
+            return sb.toString();
+        } catch (Exception e) {
+            //e.printStackTrace();
+            return null;
+        }
+    }
+
+    public static String readFile(String url) {
+        return readFile(new File(url));
+    }
+
+    public static String readFile(File file) {
+        try {
+            BufferedReader in = new BufferedReader(new FileReader(file));
+
+            StringBuilder sb = new StringBuilder();
+
+            String l = "";
+            boolean firstline = true;
+            do {
+                sb.append(l);
+                l = in.readLine();
+                if (l != null && !firstline) {
+                    sb.append("\n");
+                    firstline = false;
+                }
+            } while (l != null);
+            in.close();
+            return sb.toString();
+        } catch (Exception e) {
+            e.printStackTrace(); //TODO tagging for future exception handling/logging
+        }
+        return null;
+    }
+
+    public static void saveFile(File file, String saveme) {
+        try {
+            file.createNewFile();
+            BufferedWriter out = new BufferedWriter(new FileWriter(file));
+            out.write(saveme);
+            out.close();
+        } catch (Exception e) {
+            System.out.println("Exception caught trying to save file. Path: " + file.getAbsolutePath());
+            e.printStackTrace(); //TODO tagging for future exception handling/logging
+        }
+    }
+
+    public static String joinStringArray(String[] args) {
+        return joinStringArray(args, "");
+    }
+
+    public static String joinArrayList(ArrayList<String> args) {
+        return joinArrayList(args, "");
+    }
+
+    public static String joinStringSet(Set<String> args) {
+        return joinStringSet(args, "");
+    }
+
+    public static String joinStringArray(String[] args, String delimiter) {
+        return joinStringArray(args, delimiter, 0);
+    }
+
+    public static String joinArrayList(ArrayList<String> args, String delimiter) {
+        return joinArrayList(args, delimiter, 0);
+    }
+
+    public static String joinStringSet(Set<String> args, String delimiter) {
+        return joinStringSet(args, delimiter, 0);
+    }
+
+    public static String joinStringArray(String[] args, String delimiter, int startingIndex) {
+        StringBuilder s = new StringBuilder();
+        for (int i = startingIndex; i < args.length; i++) {
+            s.append(args[i]);
+            if (!(i + 1 >= args.length)) {
+                s.append(delimiter);
+            }
+        }
+        return s.toString();
+    }
+
+    public static String joinArrayList(ArrayList<String> args, String delimiter, int startingIndex) {
+        StringBuilder s = new StringBuilder();
+        for (int i = startingIndex; i < args.size(); i++) {
+            s.append(args.get(i));
+            if (!(i + 1 >= args.size())) {
+                s.append(delimiter);
+            }
+        }
+        return s.toString();
+    }
+
+    public static String joinStringSet(Set<String> args, String delimiter, int startingIndex) {
+        int count = startingIndex;
+        StringBuilder s = new StringBuilder();
+        for (String string : args) {
+            if (count >= startingIndex) {
+                s.append(string);
+                if (count + 1 < args.size()) {
+                    s.append(delimiter);
+                }
+            }
+            count++;
+        }
+        return s.toString();
+    }
+
+    public static String getStringFromIndex(int index, String[] args) {
+        String s = "";
+        for (int i = index; i < args.length; i++) {
+            s += args[i] + " ";
+        }
+        return s.trim();
+    }
+
+    public static void setLocationMidScreen(Window frame, int screen) {
+        frame.setLocation(getLocationMidScreen(frame, screen));
+    }
+
+    public static void setLocationMidScreen(Window frame) {
+        setLocationMidScreen(frame, 0);
+    }
+
+    public static Point getLocationMidScreen(Window frame, int screen) {
+        DisplayMode monitor = GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices()[screen]
+                .getDisplayMode();
+        Point p = new Point(monitor.getWidth() / 2 - (frame.getWidth() / 2),
+                monitor.getHeight() / 2 - (frame.getHeight() / 2));
+
+        return p;
+    }
+
+    public static Point getLocationMidScreen(Window frame) {
+        return getLocationMidScreen(frame, 0);
+    }
+
+    public static String getTimeStamp(String format) {
+        return getTimeStamp(format, System.currentTimeMillis());
+    }
+
+    public static String getTimeStamp(String format, long time) {
+        return new SimpleDateFormat(format).format(time);
+    }
+
+    public static boolean isEven(long i) {
+        return i % 2 == 0;
+    }
+
+    public static void setBackgroundColorRecursively(Container container, Color color) {
+        for (int i = 0; i < container.getComponentCount(); i++) {
+            Component component = container.getComponent(i);
+            if (component instanceof Container) {
+                setBackgroundColorRecursively((Container) component, color);
+            }
+            component.setBackground(color);
+        }
+    }
+
+    public static Color randomColor() {
+        Color c = new Color(random.nextInt(255), random.nextInt(255), random.nextInt(255), 255);
+        return c;
+    }
+
+    public static void sleep(int sleep) {
+        try {
+            Thread.sleep(sleep);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static String convertTeamColorToName(int teamValue) {
+        Team[] teams = Team.values();
+
+        for (Team team : teams) {
+            if (team.getValue() == teamValue) {
+                return StringUtils.capitalize(team.toString().toLowerCase().replaceAll("team_", ""));
+            }
+        }
+        return "UNKNOWN_TEAM";
+    }
 }

--- a/src/me/corriekay/pokegoutil/utils/Utilities.java
+++ b/src/me/corriekay/pokegoutil/utils/Utilities.java
@@ -267,8 +267,8 @@ public abstract class Utilities {
     }
 
     public static void sleepRandom(int minMilliseconds, int maxMilliseconds) {
-        int from = Math.min(minMilliseconds, maxMilliseconds);
-        int to = Math.max(minMilliseconds, maxMilliseconds);
+        int from = Math.max(minMilliseconds, maxMilliseconds);
+        int to = Math.min(minMilliseconds, maxMilliseconds);
         try {
             int randomInt = random.nextInt((from - to) + 1) + to;
             System.out.println("Waiting " + (randomInt / 1000.0F) + " seconds.");

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -36,6 +36,7 @@ import javax.swing.table.TableRowSorter;
 
 import POGOProtos.Networking.Responses.NicknamePokemonResponseOuterClass.NicknamePokemonResponse;
 import POGOProtos.Networking.Responses.SetFavoritePokemonResponseOuterClass;
+import me.corriekay.pokegoutil.utils.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -54,12 +55,6 @@ import POGOProtos.Enums.PokemonFamilyIdOuterClass.PokemonFamilyId;
 import POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
 import POGOProtos.Networking.Responses.ReleasePokemonResponseOuterClass;
 import POGOProtos.Networking.Responses.UpgradePokemonResponseOuterClass;
-import me.corriekay.pokegoutil.utils.Config;
-import me.corriekay.pokegoutil.utils.GhostText;
-import me.corriekay.pokegoutil.utils.JTableColumnPacker;
-import me.corriekay.pokegoutil.utils.LDocumentListener;
-import me.corriekay.pokegoutil.utils.PokeHandler;
-import me.corriekay.pokegoutil.utils.PokemonCpUtils;
 
 @SuppressWarnings("serial")
 public class PokemonTab extends JPanel {
@@ -228,6 +223,13 @@ public class PokemonTab extends JPanel {
                     err.increment();
                     System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " failed! Code: " + result.toString() + "; Nick: " + PokeHandler.generatePokemonNickname(renamePattern, pokemon));
                 }
+
+                // If not last element, sleep until the next one
+                if (!selection.get(selection.size() - 1).equals(pokemon)) {
+                    int sleepMin = Config.getConfig().getInt("delay.rename.min", 1000);
+                    int sleepMax = Config.getConfig().getInt("delay.rename.max", 5000);
+                    Utilities.sleepRandom(sleepMin, sleepMax);
+                }
             };
 
             handler.bulkRenameWithPattern(renamePattern, perPokeCallback);
@@ -270,6 +272,13 @@ public class PokemonTab extends JPanel {
                         System.out.println(
                                 "Error transferring " + PokeHandler.getLocalPokeName(poke) + ", result: " + result);
                         err.increment();
+                    }
+
+                    // If not last element, sleep until the next one
+                    if (!selection.get(selection.size() - 1).equals(poke)) {
+                        int sleepMin = Config.getConfig().getInt("delay.transfer.min", 1000);
+                        int sleepMax = Config.getConfig().getInt("delay.transfer.max", 5000);
+                        Utilities.sleepRandom(sleepMin, sleepMax);
                     }
                 } catch (Exception e) {
                     err.increment();
@@ -322,6 +331,13 @@ public class PokemonTab extends JPanel {
                             err.increment();
                             System.out.println("Error evolving " + PokeHandler.getLocalPokeName(poke) + ", result: " + er.toString());
                         }
+
+                        // If not last element, sleep until the next one
+                        if (!selection.get(selection.size() - 1).equals(poke)) {
+                            int sleepMin = Config.getConfig().getInt("delay.evolve.min", 3000);
+                            int sleepMax = Config.getConfig().getInt("delay.evolve.max", 12000);
+                            Utilities.sleepRandom(sleepMin, sleepMax);
+                        }
                     } catch (Exception e) {
                         err.increment();
                         System.out.println("Error evolving " + PokeHandler.getLocalPokeName(poke) + "! " + e.getMessage());
@@ -370,6 +386,13 @@ public class PokemonTab extends JPanel {
                             System.out.println(
                                     "Error powering up " + PokeHandler.getLocalPokeName(poke) + ", result: " + result.toString());
                         }
+
+                        // If not last element, sleep until the next one
+                        if (!selection.get(selection.size() - 1).equals(poke)) {
+                            int sleepMin = Config.getConfig().getInt("delay.powerUp.min", 1000);
+                            int sleepMax = Config.getConfig().getInt("delay.powerUp.max", 5000);
+                            Utilities.sleepRandom(sleepMin, sleepMax);
+                        }
                     } catch (Exception e) {
                         err.increment();
                         System.out.println("Error powering up " + PokeHandler.getLocalPokeName(poke) + "! " + e.getMessage());
@@ -409,20 +432,21 @@ public class PokemonTab extends JPanel {
                             System.out.println(
                                     "Favorite for " + PokeHandler.getLocalPokeName(poke) + " set to " + !poke.isFavorite() + ", Result: Success!");
                             success.increment();
-
                         } else {
                             err.increment();
                             System.out.println(
-                                    "Error toggling favorite for " + PokeHandler.getLocalPokeName(poke) + " , result: " + result.toString());
+                                    "Error toggling favorite for " + PokeHandler.getLocalPokeName(poke) + ", result: " + result.toString());
                         }
 
+                        // If not last element, sleep until the next one
+                        if (!selection.get(selection.size() - 1).equals(poke)) {
+                            int sleepMin = Config.getConfig().getInt("delay.favorite.min", 1000);
+                            int sleepMax = Config.getConfig().getInt("delay.favorite.max", 3000);
+                            Utilities.sleepRandom(sleepMin, sleepMax);
+                        }
                     } catch (Exception e) {
-
-                        // if the error was "Contents of buffer are null"
-                        // it was likely successful
-                        // https://github.com/Grover-c13/PokeGOAPI-Java/issues?utf8=%E2%9C%93&q=Contents%20of%20buffer%20are%20null%20
                         err.increment();
-                        System.out.println("Error toggling Pokémon " + PokeHandler.getLocalPokeName(poke) + " favorite! " + e.getMessage());
+                        System.out.println("Error toggling favorite for " + PokeHandler.getLocalPokeName(poke) + "! " + e.getMessage());
                     }
                 });
                 try {

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -120,7 +120,10 @@ public class PokemonTab extends JPanel {
         }.execute());
         topPanel.add(toggleFavorite, gbc);
         toggleFavorite.addActionListener(l -> new SwingWorker<Void, Void>() {
-            protected Void doInBackground() throws Exception { toggleFavorite(); return null; }
+            protected Void doInBackground() throws Exception {
+                toggleFavorite();
+                return null;
+            }
         }.execute());
 
         ivTransfer.addKeyListener(
@@ -391,8 +394,8 @@ public class PokemonTab extends JPanel {
     //feature added by Ben Kauffman
     private void toggleFavorite() {
         ArrayList<Pokemon> selection = getSelectedPokemon();
-        if(selection.size() > 0) {
-            if(confirmOperation("Toggle Favorite", selection)) {
+        if (selection.size() > 0) {
+            if (confirmOperation("Toggle Favorite", selection)) {
                 MutableInt err = new MutableInt(), success = new MutableInt(), total = new MutableInt(1);
                 selection.forEach(poke -> {
                     try {
@@ -402,7 +405,7 @@ public class PokemonTab extends JPanel {
                         System.out.println("Attempting to set favorite for " + PokeHandler.getLocalPokeName(poke) + " to " + !poke.isFavorite() + "...");
                         go.getPlayerProfile().updateProfile();
 
-                        if(result == SetFavoritePokemonResponseOuterClass.SetFavoritePokemonResponse.Result.SUCCESS) {
+                        if (result == SetFavoritePokemonResponseOuterClass.SetFavoritePokemonResponse.Result.SUCCESS) {
                             System.out.println(
                                     "Favorite for " + PokeHandler.getLocalPokeName(poke) + " set to " + !poke.isFavorite() + ", Result: Success!");
                             success.increment();


### PR DESCRIPTION
I've already implemented that for my personal use, so why not share it directly, even when it was originally planned for v0.1.3, and not the next release.

There are random delays between two reasonable numbers for each bulk operation. It waits that much seconds if there is still a next element.
The delay can be modified inside the `config.json`.

Resolves #84.
