### PR TITLE
Renaming ignored if the nickname is the same

### DIFF
--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
@@ -92,6 +92,11 @@ public class PokeHandler {
     private static NicknamePokemonResponse.Result renWPattern(String pattern, Pokemon pokemon, Pattern regex) {
         String pokeNick = generatePokemonNickname(pattern, pokemon, regex);
 
+        if(pokeNick.equals(pokemon.getNickname())) {
+            // Why renaming to the same nickname?
+            return NicknamePokemonResponse.Result.UNSET; // FIXME: Enhance the response?
+        }
+
         // Actually renaming the Pokémon with the calculated nickname
         try {
             NicknamePokemonResponse.Result result = pokemon.renamePokemon(pokeNick);

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -198,13 +198,17 @@ public class PokemonTab extends JPanel {
             if (result.getNumber() == NicknamePokemonResponse.Result.SUCCESS_VALUE) {
                 success.increment();
                 System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " from \"" + pokemon.getNickname() + "\" to \"" + PokeHandler.generatePokemonNickname(renamePattern, pokemon) + "\", Result: Success!");
+            } else if (result.getNumber() == NicknamePokemonResponse.Result.UNSET_VALUE) { // FIXME: See PokeHandler.java@97
+                success.increment();
+                System.out.println("Not renaming " + PokeHandler.getLocalPokeName(pokemon) + ", already named " + PokeHandler.generatePokemonNickname(renamePattern, pokemon));
             } else {
                 err.increment();
                 System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " failed! Code: " + result.toString() + "; Nick: " + PokeHandler.generatePokemonNickname(renamePattern, pokemon));
             }
 
-            // If not last element, sleep until the next one
-            if (!selection.get(selection.size() - 1).equals(pokemon)) {
+            // If not last element, sleep until the next one and the rename was successful
+            if (!selection.get(selection.size() - 1).equals(pokemon)
+                    && result.getNumber() == NicknamePokemonResponse.Result.SUCCESS_VALUE) {
                 int sleepMin = Config.getConfig().getInt("delay.rename.min", 1000);
                 int sleepMax = Config.getConfig().getInt("delay.rename.max", 5000);
                 Utilities.sleepRandom(sleepMin, sleepMax);


### PR DESCRIPTION
Please note that I used the NicknamePokemonResponse.Result.UNSET to know if the rename was skipped or not in order not to change the headers.
I do think there should be a better way to acknowledge the skipping of a rename than using NicknamePokemon, so if you've any suggestions about it.
