### PR TITLE
Fix "in gym" on bulk operations

### DIFF
--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -301,7 +301,7 @@ public class PokemonTab extends JPanel {
                     skipped.increment();
                     return;
                 }
-                if (poke.getFromFort()) {
+                if (!poke.getDeployedFortId().isEmpty()) {
                     System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp() + " CP is in gym, skipping.");
                     skipped.increment();
                     return;
@@ -351,7 +351,7 @@ public class PokemonTab extends JPanel {
                 selection.forEach(poke -> {
                     System.out.println("Doing Evolve " + total.getValue() + " of " + selection.size());
                     total.increment();
-                    if (poke.getFromFort()) {
+                    if (!poke.getDeployedFortId().isEmpty()) {
                         System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp() + " CP is in gym, skipping.");
                         skipped.increment();
                         return;
@@ -417,7 +417,7 @@ public class PokemonTab extends JPanel {
                     try {
                         System.out.println("Doing Power Up " + total.getValue() + " of " + selection.size());
                         total.increment();
-                        if (poke.getFromFort()) {
+                        if (!poke.getDeployedFortId().isEmpty()) {
                             System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp() + " CP is in gym, skipping.");
                             skipped.increment();
                             return;


### PR DESCRIPTION
Fixes #227.

It said that the Pokémon is in gym even if it wasn't quite often.
Seems to be a bug with `.getFromFort()` in the pogo API, so we use `!.getDeployedFortId().isEmpty()` now, which is more correct.
