### PR TITLE
Fixed Pokémon name issue for non-latin languages

### DIFF
--- a/src/me/corriekay/pokegoutil/utils/Utilities.java
+++ b/src/me/corriekay/pokegoutil/utils/Utilities.java
@@ -4,23 +4,23 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.commons.lang3.StringUtils;
 
 import java.awt.*;
-import java.util.Arrays;
-import java.util.Locale;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 public final class Utilities {
     private Utilities() { /* Prevent initializing this class */ }
 
-    private static final Locale[] latins = { Locale.ENGLISH, Locale.FRENCH, Locale.GERMAN };
+    private static final CharsetEncoder iso88591Encoder = Charset.forName("ISO-8859-1").newEncoder();
     private static final Random random = new Random(System.currentTimeMillis());
 
     public static boolean isEven(long i) {
         return i % 2 == 0;
     }
 
-    public static boolean isLatin(Locale locale) {
-        return Arrays.stream(latins).anyMatch(x -> x.equals(locale));
+    public static boolean isLatin(String str) {
+        return iso88591Encoder.canEncode(str);
     }
 
     /**

--- a/src/me/corriekay/pokegoutil/utils/Utilities.java
+++ b/src/me/corriekay/pokegoutil/utils/Utilities.java
@@ -4,16 +4,23 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.commons.lang3.StringUtils;
 
 import java.awt.*;
+import java.util.Arrays;
+import java.util.Locale;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 public final class Utilities {
     private Utilities() { /* Prevent initializing this class */ }
 
+    private static final Locale[] latins = { Locale.ENGLISH, Locale.FRENCH, Locale.GERMAN };
     private static final Random random = new Random(System.currentTimeMillis());
 
     public static boolean isEven(long i) {
         return i % 2 == 0;
+    }
+
+    public static boolean isLatin(Locale locale) {
+        return Arrays.stream(latins).anyMatch(x -> x.equals(locale));
     }
 
     /**

--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
@@ -125,15 +125,14 @@ public class PokeHandler {
             locale = new Locale(langar[0], langar[1]);
         }
 
+        String name = PokeNames.getDisplayName(id, locale);
         // For non-latin
-        if (!Utilities.isLatin(locale))
-        {
-             return PokeNames.getDisplayName(id, locale);
+        if (!Utilities.isLatin(name)) {
+             return name;
         }
 
-        String name = null;
         try {
-            name = new String(PokeNames.getDisplayName(id, locale).getBytes("ISO-8859-1"), "UTF-8");
+            name = new String(name.getBytes("ISO-8859-1"), "UTF-8");
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
         }

--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
@@ -125,6 +125,12 @@ public class PokeHandler {
             locale = new Locale(langar[0], langar[1]);
         }
 
+        // For non-latin
+        if (!Utilities.isLatin(locale))
+        {
+             return PokeNames.getDisplayName(id, locale);
+        }
+
         String name = null;
         try {
             name = new String(PokeNames.getDisplayName(id, locale).getBytes("ISO-8859-1"), "UTF-8");

--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
@@ -134,8 +134,6 @@ public class PokeHandler {
         String name = null;
         try {
             name = new String(PokeNames.getDisplayName(id, locale).getBytes("ISO-8859-1"), "UTF-8");
-            name = StringUtils.capitalize(name.toLowerCase());
-            name = name.replaceAll("_male", "♂").replaceAll("_female", "♀");
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
         }

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -164,7 +164,7 @@ public class PokemonTab extends JPanel {
         topPanel.add(searchBar, gbc);
 
         // pokemon name language drop down
-        String[] locales = {"en", "de", "fr", "ru", "zh_CN", "zh_HK"};
+        String[] locales = {"en", "de", "fr", "ru", "zh_CN", "zh_HK", "ja"};
         JComboBox<String> pokelang = new JComboBox<>(locales);
         String locale = config.getString(ConfigKey.LANGUAGE);
         pokelang.setSelectedItem(locale);


### PR DESCRIPTION
# Issue

Pokémon names are "???" in non-latin languages.

![ru](https://cloud.githubusercontent.com/assets/6265511/17665390/aadb88ca-6335-11e6-89b0-352dfbe6d589.png)

`getBytes("ISO-8859-1")` converts non-latin char to "?".
# Fixed

![ru_fixed](https://cloud.githubusercontent.com/assets/6265511/17665438/f341ce4e-6335-11e6-9860-4ade700773d5.png)

![zh_fixed](https://cloud.githubusercontent.com/assets/6265511/17665445/fc6c3446-6335-11e6-9ddb-8ac6a7af0ddc.png)
# Including
- Removed redundant code
  - all uppercase and "_male" and "_female" are no longer used in PokeGOAPI

Current Pokémon names in PokeGOAPI:
[PokeGOAPI-Java/pokemon_names.properties at 0e196d45ffb0260734b2e070d95866984d15d435 · Grover-c13/PokeGOAPI-Java · GitHub](https://github.com/Grover-c13/PokeGOAPI-Java/blob/0e196d45ffb0260734b2e070d95866984d15d435/library/src/main/resources/pokemon_names.properties)
- Added japanese to language switcher

![ja_fixed](https://cloud.githubusercontent.com/assets/6265511/17665449/01848956-6336-11e6-9ab5-3b170a56c8c6.png)
