### PR TITLE
Add CP Evolved column + cpForLevel function

### DIFF
--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokemonCpUtils.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokemonCpUtils.java
@@ -131,7 +131,7 @@ public class PokemonCpUtils {
     }
 
     /**
-     * Get the maximum CP from the values
+     * Get the maximum CP for the given values
      *
      * @param attack       All attack values combined
      * @param defense      All defense values combined
@@ -141,8 +141,22 @@ public class PokemonCpUtils {
      */
     public static int getMaxCpForTrainerLevel(int attack, int defense, int stamina, int trainerLevel) {
         float maxPokemonLevel = Math.min(40.5f, trainerLevel + 1.5F);
-        float maxCpMultplier = LEVEL_CPMULTIPLIER.get(maxPokemonLevel);
-        return (int) ((double) attack * Math.pow((double) defense, 0.5D) * Math.pow((double) stamina, 0.5D) * Math.pow((double) maxCpMultplier, 2.0D) / 10.0D);
+        return getCpForPokemonLevel(attack, defense, stamina, maxPokemonLevel);
+    }
+
+    /**
+     * Get the CP for the given values
+     *
+     * @param attack       All attack values combined
+     * @param defense      All defense values combined
+     * @param stamina      All stamina values combined
+     * @param level the Pokémon level for which the CP should be calculated
+     * @return Maximum CP for these levels
+     */
+    public static int getCpForPokemonLevel(int attack, int defense, int stamina, float level) {
+        float pokemonLevel = Math.min(40.5f, level);
+        float cpMultiplier = LEVEL_CPMULTIPLIER.get(pokemonLevel);
+        return (int) ((double) attack * Math.pow((double) defense, 0.5D) * Math.pow((double) stamina, 0.5D) * Math.pow((double) cpMultiplier, 2.0D) / 10.0D);
     }
 
     /**

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -716,7 +716,7 @@ public class PokemonTab extends JPanel {
          * 16 Integer - Max Evolved CP (Current)
          * 17 Integer - Max Evolved CP
          * 18 Integer - Candies of type
-         * 19 String - Candies to Evolve
+         * 19 String(Nullable Int) - Candies to Evolve
          * 20 Integer - Star Dust to level
          * 21 String - Pokeball Type
          * 22 String(Date) - Caught at
@@ -726,6 +726,7 @@ public class PokemonTab extends JPanel {
          * 26 Integer - gymDefense
          * 27 Double - Move 1 Rating
          * 28 Double - Move 2 Rating
+         * 29 String(Nullable Int) - CP Evolved
          */
         ConfigNew config = ConfigNew.getConfig();
 
@@ -785,6 +786,7 @@ public class PokemonTab extends JPanel {
             trs.setComparator(26, cLong);
             trs.setComparator(27, cDouble);
             trs.setComparator(28, cDouble);
+            trs.setComparator(29, cNullableInt);
             setRowSorter(trs);
             List<SortKey> sortKeys = new ArrayList<>();
             sortKeys.add(new SortKey(sortColIndex1, sortOrder1));
@@ -854,6 +856,7 @@ public class PokemonTab extends JPanel {
         private final ArrayList<Long> gymDefenseCol = new ArrayList<>();//26
         private final ArrayList<Double> move1RatingCol = new ArrayList<>(),//27
                 move2RatingCol = new ArrayList<>();//28
+        private final ArrayList<String> cpEvolvedCol = new ArrayList<>();//29
 
         @Deprecated
         private PokemonTableModel(PokemonGo go, List<Pokemon> pokes, PokemonTable pt) {
@@ -932,6 +935,7 @@ public class PokemonTab extends JPanel {
                 if (highestFamilyId == p.getPokemonId()) {
                     maxEvolvedCpCurrentCol.add(i.getValue(), maxCpCurrent);
                     maxEvolvedCpCol.add(i.getValue(), maxCp);
+                    cpEvolvedCol.add(i.getValue(), "-");
                 } else if (highestFamilyMeta == null) {
                     System.out.println("Error: Cannot find meta data for " + highestFamilyId.name());
                 } else {
@@ -940,6 +944,7 @@ public class PokemonTab extends JPanel {
                     int stamina = highestFamilyMeta.getBaseStamina() + p.getIndividualStamina();
                     maxEvolvedCpCurrentCol.add(i.getValue(), PokemonCpUtils.getMaxCpForTrainerLevel(attack, defense, stamina, trainerLevel));
                     maxEvolvedCpCol.add(i.getValue(), PokemonCpUtils.getMaxCp(attack, defense, stamina));
+                    cpEvolvedCol.add(i.getValue(), String.valueOf(PokemonCpUtils.getCpForPokemonLevel(attack, defense, stamina, p.getLevel())));
                 }
 
                 try {
@@ -1034,6 +1039,8 @@ public class PokemonTab extends JPanel {
                     return "Move 1 Rating";
                 case 28:
                     return "Move 2 Rating";
+                case 29:
+                    return "CP Evolved";
                 default:
                     return "UNKNOWN?";
             }
@@ -1041,7 +1048,7 @@ public class PokemonTab extends JPanel {
 
         @Override
         public int getColumnCount() {
-            return 29;
+            return 30;
         }
 
         @Override
@@ -1110,6 +1117,8 @@ public class PokemonTab extends JPanel {
                     return move1RatingCol.get(rowIndex);
                 case 28:
                     return move2RatingCol.get(rowIndex);
+                case 29:
+                    return cpEvolvedCol.get(rowIndex);
                 default:
                     return null;
             }


### PR DESCRIPTION
Resolves #253.

Added a column which display what the CP of the Pokémon is when fully evolved, but without levelup to max.
Should help many users that want to level-up their best stuff but don't spend tons of dust on them usually.

Also refactored the `PokemonCpUtils` to have a function which directly calculates the CP given by attack, defense, stamina and level.
