### PR TITLE
Rename cut warning

### DIFF
--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokeNick.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokeNick.java
@@ -1,0 +1,63 @@
+package me.corriekay.pokegoutil.utils.pokemon;
+
+import com.pokegoapi.api.pokemon.Pokemon;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PokeNick {
+
+    public static final int MAX_NICKNAME_LENGTH = 12;
+
+    /**
+     * Helper variable to get the rename Regex-Pattern so we don't have to rebuild
+     * it every time we process a pokemon. This should save resources.
+     */
+    private static Pattern regex = Pattern.compile("(%([a-zA-Z0-9_]+)%)");
+
+    // Constructor parameters
+    public String pattern;
+    public Pokemon pokemon;
+
+    // Calculated variables
+    public String fullNickname;
+    public String usableNickname;
+
+    public PokeNick(String pattern, Pokemon pokemon) {
+        this.pattern = pattern;
+        this.pokemon = pokemon;
+        fullNickname = pattern;
+        Matcher m = regex.matcher(pattern);
+        while (m.find()) {
+            String fullExpr = m.group(1);
+            String exprName = m.group(2);
+
+            try {
+                // Get ReplacePattern Object and use its get method to get the replacement string.
+                // Replace in nickname.
+                PokeHandler.ReplacePattern rep = PokeHandler.ReplacePattern.valueOf(exprName.toUpperCase());
+                String repStr = rep.get(pokemon);
+                fullNickname = fullNickname.replace(fullExpr, repStr);
+            } catch (IllegalArgumentException iae) {
+                // Do nothing, nothing to replace
+            }
+        }
+
+        // Set the stuff we need
+        usableNickname = StringUtils.substring(fullNickname, 0, MAX_NICKNAME_LENGTH);
+    }
+
+    @Override
+    public String toString() {
+        return usableNickname;
+    }
+
+    public boolean isTooLong() {
+        return fullNickname.length() > MAX_NICKNAME_LENGTH;
+    }
+
+    public boolean equals(String otherNick) {
+        return this.toString().equals(otherNick);
+    }
+}

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -19,6 +19,7 @@ import me.corriekay.pokegoutil.utils.helpers.DateHelper;
 import me.corriekay.pokegoutil.utils.helpers.JTableColumnPacker;
 import me.corriekay.pokegoutil.utils.helpers.LDocumentListener;
 import me.corriekay.pokegoutil.utils.pokemon.PokeHandler;
+import me.corriekay.pokegoutil.utils.pokemon.PokeNick;
 import me.corriekay.pokegoutil.utils.pokemon.PokemonCpUtils;
 import me.corriekay.pokegoutil.utils.pokemon.PokemonUtils;
 import me.corriekay.pokegoutil.utils.ui.GhostText;
@@ -252,8 +253,10 @@ public class PokemonTab extends JPanel {
             System.out.println("Doing Rename " + total.getValue() + " of " + selection.size());
             total.increment();
 
+            PokeNick pokeNick = PokeHandler.generatePokemonNickname(renamePattern, pokemon);
+
             // We check if the Pokemon was skipped
-            boolean isSkipped = (pokemon.getNickname().equals(PokeHandler.generatePokemonNickname(renamePattern, pokemon))
+            boolean isSkipped = (pokeNick.equals(pokemon.getNickname())
                     && result.getNumber() == NicknamePokemonResponse.Result.UNSET_VALUE);
             if (isSkipped) {
                 System.out.println("Skipped renaming " + PokeHandler.getLocalPokeName(pokemon) + ", already named " + pokemon.getNickname());
@@ -263,6 +266,9 @@ public class PokemonTab extends JPanel {
 
             if (result.getNumber() == NicknamePokemonResponse.Result.SUCCESS_VALUE) {
                 success.increment();
+                if (pokeNick.isTooLong()) {
+                    System.out.print("Warning. Nickname \"" + pokeNick.fullNickname + "\" is too long. Get's cut to: " + pokeNick.toString());
+                }
                 System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " from \"" + pokemon.getNickname() + "\" to \"" + PokeHandler.generatePokemonNickname(renamePattern, pokemon) + "\", Result: Success!");
             } else {
                 err.increment();

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -267,7 +267,7 @@ public class PokemonTab extends JPanel {
             if (result.getNumber() == NicknamePokemonResponse.Result.SUCCESS_VALUE) {
                 success.increment();
                 if (pokeNick.isTooLong()) {
-                    System.out.print("Warning. Nickname \"" + pokeNick.fullNickname + "\" is too long. Get's cut to: " + pokeNick.toString());
+                    System.out.println("WARNING: Nickname \"" + pokeNick.fullNickname + "\" is too long. Get's cut to: " + pokeNick.toString());
                 }
                 System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " from \"" + pokemon.getNickname() + "\" to \"" + PokeHandler.generatePokemonNickname(renamePattern, pokemon) + "\", Result: Success!");
             } else {


### PR DESCRIPTION
Refactored generating of Pokémon Nickname generation.

Yeah, I know the patterns are still defined in the PokeHandler. But see `PokeNick` class more as a part of the PokeHandler that makes working with the generated Nick easier.
I guess I am too used to case classes in Scala, so that's what I missed here. A simple, small case class for PokeNick as return type.
But I guess this solution here is fine too and makes the code a bit more clean and seperated.
