### PR TITLE
Fix Mac script, not use javaw

### DIFF
--- a/prep/RunOnUnixLikeSystems.sh
+++ b/prep/RunOnUnixLikeSystems.sh
@@ -1,1 +1,1 @@
-start javaw -jar BlossomsPogoManager.jar
+start java -jar BlossomsPogoManager.jar


### PR DESCRIPTION
Javaw is not automatically installed on Mac OS with the normal JRE.
So we use java instead.

Fixes #266.
