### PR TITLE
Gitaliases + Unix script shebang line

### DIFF
--- a/.gitaliases
+++ b/.gitaliases
@@ -1,0 +1,47 @@
+[alias]
+    #########################
+    # Needed base functions #
+    #########################
+    # Get the current branch name (not so useful in itself, but used in other aliases)
+    branch-name = !"git rev-parse --abbrev-ref HEAD"
+    # Creates given branch based on develop and deletes the one original one with the same name
+    create-with-delete = !"f() { git checkout develop && git branch -d $@ && git checkout -b $@; }; f"
+
+
+    ####################
+    # Simple Shortcuts #
+    ####################
+    # Go to the branch with given name
+    go = "checkout"
+    # Go back to develop branch
+    return = "checkout develop"
+    # Removes the last commit
+    undo-commit = reset --soft HEAD~1
+
+    ####################
+    # Primary Commands #
+    ####################
+    # Creates given branch based on master and checks it out. Just a shortcut of git checkout -b
+    work = !"f() { git return && git checkout -b $@; }; f"
+    # Refresh the current branch from upstream
+    refresh = !"f() { git pull upstream $(git branch-name) && git push; }; f"
+    # Push the current branch to the remote "origin", and set it to track the upstream branch
+    publish = !"git push -u origin $(git branch-name)"
+    # Delete the remote version of the current branch
+    unpublish = "!git push origin :$(git branch-name)"
+    # Resets the current branch to origin
+    reset-to-origin = !"git reset --hard origin/$(git branch-name)"
+    # Recreates current branch based on develop
+    recreate = !"f() { git create-with-delete $(git branch-name); }; f"
+    # Remove all branches that got already merged
+    tidy = !"git return && git refresh && git fetch --all -p && git branch -vv | grep ': gone]' | awk '{ print $1 }' | xargs -n 1 git branch -d"
+
+    ###########
+    # Helpers #
+    ###########
+    # Lists all existing aliases
+    list-aliases = "!git config -l | grep alias | cut -c 7-"
+    # Create a Test branch based on develop
+    test = !"git work Test"
+    # Deletes the test branch and goes back to develop
+    test-finished = !"git return && git branch -D Test"

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -20,6 +20,9 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
+  <component name="ProjectPlainTextFileTypeManager">
+    <file url="file://$PROJECT_DIR$/.gitignore" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/prep/RunOnUnixLikeSystems.sh
+++ b/prep/RunOnUnixLikeSystems.sh
@@ -1,1 +1,2 @@
+#!/usr/bin/env bash
 start java -jar BlossomsPogoManager.jar


### PR DESCRIPTION
Added my git aliases to the repo. I need them on every of my work computers, so it would be nice to distribute them with the project already.
And guess they do not hurt :P You guys could even use them yourself. Just go to your local `.git/config` file and add the following:

```
[include]
    path = ../.gitaliases
```

On top of that I have added the shebang line for the unix shell script. Heard that would be good style for unix scripts. Whyever, I don't understand, but let's do it.
