### PR TITLE
Major refactoring and some fixes

### DIFF
--- a/src/me/corriekay/pokegoutil/utils/Utilities.java
+++ b/src/me/corriekay/pokegoutil/utils/Utilities.java
@@ -10,7 +10,9 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 public final class Utilities {
-    private Utilities() { /* Prevent initializing this class */ }
+    /* Prevent initializing this class */
+    private Utilities() {
+    }
 
     private static final CharsetEncoder iso88591Encoder = Charset.forName("ISO-8859-1").newEncoder();
     private static final Random random = new Random(System.currentTimeMillis());
@@ -36,6 +38,7 @@ public final class Utilities {
     public static String percentageWithTwoCharacters(double number, double maximum) {
         return percentageWithTwoCharacters(Math.min(number / maximum, maximum));
     }
+
     public static String percentageWithTwoCharacters(double decimalNumber) {
         long rounded = Math.round(percentage(decimalNumber));
         return (rounded < 100) ? StringUtils.leftPad(String.valueOf(rounded), 2, '0') : "XX";
@@ -70,20 +73,22 @@ public final class Utilities {
     public static String getRealExceptionMessage(Exception e) {
         String message = e.getMessage();
         if (e instanceof InvalidProtocolBufferException || "Contents of buffer are null".equals(message)) {
-            message = "Server hasn't responded in time. Seems to be busy. The action may have been successful though. (" + message + ")";
+            message = "Server hasn't responded in time. "
+                    + "Seems to be busy. "
+                    + "The action may have been successful though. (" + message + ")";
         }
         return message;
     }
-    
-    public static String concatString(char delimeter, String ... strings){
-        if(strings.length == 0){
+
+    public static String concatString(char delimeter, String... strings) {
+        if (strings.length == 0) {
             return "";
-        }else{
-            String s = strings[0];
-            for(int i = 1; i < strings.length; i ++){
-                s += delimeter + strings[i];
-            }
-            return s;
         }
+
+        String s = strings[0];
+        for (int i = 1; i < strings.length; i++) {
+            s += delimeter + strings[i];
+        }
+        return s;
     }
 }

--- a/src/me/corriekay/pokegoutil/utils/Utilities.java
+++ b/src/me/corriekay/pokegoutil/utils/Utilities.java
@@ -74,4 +74,16 @@ public final class Utilities {
         }
         return message;
     }
+    
+    public static String concatString(char delimeter, String ... strings){
+        if(strings.length == 0){
+            return "";
+        }else{
+            String s = strings[0];
+            for(int i = 1; i < strings.length; i ++){
+                s += delimeter + strings[i];
+            }
+            return s;
+        }
+    }
 }

--- a/src/me/corriekay/pokegoutil/utils/helpers/DateHelper.java
+++ b/src/me/corriekay/pokegoutil/utils/helpers/DateHelper.java
@@ -1,6 +1,5 @@
 package me.corriekay.pokegoutil.utils.helpers;
 
-import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;

--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
@@ -24,7 +24,7 @@ public class PokeHandler {
     private ArrayList<Pokemon> mons;
 
     public PokeHandler(Pokemon pokemon) {
-        this(new Pokemon[]{pokemon});
+        this(new Pokemon[] { pokemon });
     }
 
     public PokeHandler(Pokemon[] pokemon) {
@@ -54,7 +54,9 @@ public class PokeHandler {
 
         if (pokeNick.equals(pokemon.getNickname())) {
             // Why renaming to the same nickname?
-            return NicknamePokemonResponse.Result.UNSET; // We need to use UNSET here. No chance to extend the enum
+            return NicknamePokemonResponse.Result.UNSET; // We need to use UNSET here. No
+                                                         // chance to
+                                                         // extend the enum
         }
 
         // Actually renaming the Pokémon with the calculated nickname
@@ -62,7 +64,9 @@ public class PokeHandler {
             NicknamePokemonResponse.Result result = pokemon.renamePokemon(pokeNick.toString());
             return result;
         } catch (LoginFailedException | RemoteServerException e) {
-            System.out.println("Error while renaming " + getLocalPokeName(pokemon) + "(" + pokemon.getNickname() + ")! " + Utilities.getRealExceptionMessage(e));
+            System.out.println("Error while renaming "
+                    + getLocalPokeName(pokemon) + "(" + pokemon.getNickname() + ")! "
+                    + Utilities.getRealExceptionMessage(e));
             return NicknamePokemonResponse.Result.UNRECOGNIZED;
         }
     }
@@ -88,7 +92,7 @@ public class PokeHandler {
         String name = PokeNames.getDisplayName(id, locale);
         // For non-latin
         if (!Utilities.isLatin(name)) {
-             return name;
+            return name;
         }
 
         try {
@@ -121,8 +125,7 @@ public class PokeHandler {
      * value.
      */
     public LinkedHashMap<Pokemon, NicknamePokemonResponse.Result> bulkRenameWithPattern(String pattern,
-                                                                                        BiConsumer<NicknamePokemonResponse.Result, Pokemon> perPokeCallback) {
-
+            BiConsumer<NicknamePokemonResponse.Result, Pokemon> perPokeCallback) {
         LinkedHashMap<Pokemon, NicknamePokemonResponse.Result> results = new LinkedHashMap<>();
 
         mons.forEach(p -> {
@@ -194,11 +197,11 @@ public class PokeHandler {
             @Override
             public String get(Pokemon p) {
                 PokemonFamilyId familyId = p.getPokemonFamily();
-		PokemonId highestFamilyId = PokemonMetaRegistry.getHightestForFamily(familyId);
-		int iv_attack = p.getIndividualAttack();
-		int iv_defense = p.getIndividualDefense();
-		int iv_stamina = p.getIndividualStamina();
-		float level = p.getLevel();
+                PokemonId highestFamilyId = PokemonMetaRegistry.getHightestForFamily(familyId);
+                int iv_attack = p.getIndividualAttack();
+                int iv_defense = p.getIndividualDefense();
+                int iv_stamina = p.getIndividualStamina();
+                float level = p.getLevel();
                 if (familyId.getNumber() == PokemonFamilyId.FAMILY_EEVEE.getNumber()) {
                     if (p.getPokemonId().getNumber() == PokemonId.EEVEE.getNumber()) {
                         PokemonMeta vap = PokemonMetaRegistry.getMeta(PokemonId.VAPOREON);
@@ -206,28 +209,35 @@ public class PokeHandler {
                         PokemonMeta jol = PokemonMetaRegistry.getMeta(PokemonId.JOLTEON);
                         if (vap != null && fla != null && jol != null) {
                             Comparator<PokemonMeta> cMeta = (m1, m2) -> {
-                                int comb1 = PokemonCpUtils.getCpForPokemonLevel(m1.getBaseAttack() + iv_attack, m1.getBaseDefense() + iv_defense, m1.getBaseStamina() + iv_stamina, level);
-                                int comb2 = PokemonCpUtils.getCpForPokemonLevel(m2.getBaseAttack() + iv_attack, m2.getBaseDefense() + iv_defense, m2.getBaseStamina() + iv_stamina, level);
+                                int comb1 = PokemonCpUtils.getCpForPokemonLevel(
+                                        m1.getBaseAttack() + iv_attack,
+                                        m1.getBaseDefense() + iv_defense,
+                                        m1.getBaseStamina() + iv_stamina, level);
+                                int comb2 = PokemonCpUtils.getCpForPokemonLevel(
+                                        m2.getBaseAttack() + iv_attack,
+                                        m2.getBaseDefense() + iv_defense,
+                                        m2.getBaseStamina() + iv_stamina, level);
                                 return comb1 - comb2;
                             };
-                            highestFamilyId = PokemonId.forNumber(Collections.max(Arrays.asList(vap, fla, jol), cMeta).getNumber());
+                            highestFamilyId = PokemonId
+                                    .forNumber(Collections.max(Arrays.asList(vap, fla, jol), cMeta).getNumber());
                         }
                     } else {
                         // This is one of the eeveelutions, so PokemonMetaRegistry.getHightestForFamily() returns Eevee.
                         // We correct that here
                         highestFamilyId = p.getPokemonId();
-		    }
-		}
-		/** 
-		 * This calculation is redundant for pokemon already evolved, but as
-		 * rename has delays anyway, this won't hurt performance.
-		 */
-		PokemonMeta highestFamilyMeta = PokemonMetaRegistry.getMeta(highestFamilyId);
-		int attack = highestFamilyMeta.getBaseAttack() + iv_attack;
-		int defense = highestFamilyMeta.getBaseDefense() + iv_defense;
-		int stamina = highestFamilyMeta.getBaseStamina() + iv_stamina;
-		return String.valueOf(PokemonCpUtils.getCpForPokemonLevel(attack, defense, stamina, level));
-	    }
+                    }
+                }
+                /**
+                 * This calculation is redundant for pokemon already evolved, but as rename has delays anyway, this
+                 * won't hurt performance.
+                 */
+                PokemonMeta highestFamilyMeta = PokemonMetaRegistry.getMeta(highestFamilyId);
+                int attack = highestFamilyMeta.getBaseAttack() + iv_attack;
+                int defense = highestFamilyMeta.getBaseDefense() + iv_defense;
+                int stamina = highestFamilyMeta.getBaseStamina() + iv_stamina;
+                return String.valueOf(PokemonCpUtils.getCpForPokemonLevel(attack, defense, stamina, level));
+            }
         },
         HP("Hit Points") {
             @Override
@@ -250,7 +260,9 @@ public class PokeHandler {
         IV_HEX("IV Values in hexadecimal, like \"9FA\" (F = 15)") {
             @Override
             public String get(Pokemon p) {
-                return (Integer.toHexString(p.getIndividualAttack()) + Integer.toHexString(p.getIndividualDefense()) + Integer.toHexString(p.getIndividualStamina())).toUpperCase();
+                return (Integer.toHexString(p.getIndividualAttack())
+                        + Integer.toHexString(p.getIndividualDefense())
+                        + Integer.toHexString(p.getIndividualStamina())).toUpperCase();
             }
         },
         IV_ATT("IV Attack") {

--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
@@ -18,8 +18,6 @@ import org.apache.commons.lang3.StringUtils;
 import java.io.UnsupportedEncodingException;
 import java.util.*;
 import java.util.function.BiConsumer;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class PokeHandler {
 

--- a/src/me/corriekay/pokegoutil/utils/windows/PokemonTable.java
+++ b/src/me/corriekay/pokegoutil/utils/windows/PokemonTable.java
@@ -58,6 +58,9 @@ public class PokemonTable extends JTable {
     // 28 String(Percentage) - Move 2 Rating
     // 29 String(Nullable Int) - CP Evolved
     // 30 String(Nullable Int) - Evolvable
+    // 31 Long - duelAbility IV
+    // 32 Double - gymOffense IV
+    // 33 Long - gymDefense IV
 
     private ConfigNew config = ConfigNew.getConfig();
 
@@ -120,7 +123,7 @@ public class PokemonTable extends JTable {
         trs.setComparator(20, c);
         trs.setComparator(22, cDate);
         trs.setComparator(24, cLong);
-        trs.setComparator(25, cLong);
+        trs.setComparator(25, cDouble);
         trs.setComparator(26, cLong);
         trs.setComparator(27, cPercentageWithTwoCharacters);
         trs.setComparator(28, cPercentageWithTwoCharacters);
@@ -176,17 +179,17 @@ public class PokemonTable extends JTable {
         gymAttackIVCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_OFFENSE_IV_MAX));
         TableColumn gymDefenseIVCol = getColumnModel().getColumn(33);
         gymDefenseIVCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_DEFENSE_IV_MAX));
-        
+
         // Magic numbers pulled from max values of their respective columns
         // in the moveset rankings spreadsheet calculations
         // @see
         // https://www.reddit.com/r/TheSilphRoad/comments/4vcobt/posthotfix_pokemon_go_full_moveset_rankings/
-        //TableColumn duelAbilityCol = this.pt.getColumnModel().getColumn(24);
-        //duelAbilityCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.DUEL_ABILITY_MAX));
-        //TableColumn gymAttackCol = this.pt.getColumnModel().getColumn(25);
-        //gymAttackCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_OFFENSE_MAX));
-        //TableColumn gymDefenseCol = this.pt.getColumnModel().getColumn(26);
-        //gymDefenseCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_DEFENSE_MAX));
+        // TableColumn duelAbilityCol = this.pt.getColumnModel().getColumn(24);
+        // duelAbilityCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.DUEL_ABILITY_MAX));
+        // TableColumn gymAttackCol = this.pt.getColumnModel().getColumn(25);
+        // gymAttackCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_OFFENSE_MAX));
+        // TableColumn gymDefenseCol = this.pt.getColumnModel().getColumn(26);
+        // gymDefenseCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_DEFENSE_MAX));
     }
 
     public void constructNewTableModel(List<Pokemon> pokes) {

--- a/src/me/corriekay/pokegoutil/utils/windows/PokemonTable.java
+++ b/src/me/corriekay/pokegoutil/utils/windows/PokemonTable.java
@@ -1,0 +1,165 @@
+package me.corriekay.pokegoutil.utils.windows;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import javax.swing.JTable;
+import javax.swing.ListSelectionModel;
+import javax.swing.RowSorter;
+import javax.swing.SortOrder;
+import javax.swing.RowSorter.SortKey;
+import javax.swing.event.TableModelEvent;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableModel;
+import javax.swing.table.TableRowSorter;
+
+import com.pokegoapi.api.PokemonGo;
+import com.pokegoapi.api.pokemon.Pokemon;
+
+import me.corriekay.pokegoutil.utils.ConfigKey;
+import me.corriekay.pokegoutil.utils.ConfigNew;
+import me.corriekay.pokegoutil.utils.helpers.DateHelper;
+import me.corriekay.pokegoutil.utils.helpers.JTableColumnPacker;
+import me.corriekay.pokegoutil.utils.pokemon.PokemonUtils;
+import me.corriekay.pokegoutil.windows.PokemonTab;
+import me.corriekay.pokegoutil.windows.PokemonTab.MoveSetRankingRenderer;
+
+public class PokemonTable extends JTable {
+
+    /**
+     * data types: 0 String - Nickname 1 Integer - Pokemon Number 2 String -
+     * Type / Pokemon 3 String(Percentage) - IV Rating 4 Double - Level 5
+     * Integer - Attack 6 Integer - Defense 7 Integer - Stamina 8 String -
+     * Type 1 9 String - Type 2 10 String - Move 1 11 String - Move 2 12
+     * Integer - CP 13 Integer - HP 14 Integer - Max CP (Current) 15 Integer
+     * - Max CP 16 Integer - Max Evolved CP (Current) 17 Integer - Max
+     * Evolved CP 18 Integer - Candies of type 19 String(Nullable Int) -
+     * Candies to Evolve 20 Integer - Star Dust to level 21 String -
+     * Pokeball Type 22 String(Date) - Caught at 23 Boolean - Favorite 24
+     * Long - duelAbility 25 Integer - gymOffense 26 Integer - gymDefense 27
+     * String(Percentage) - Move 1 Rating 28 String(Percentage) - Move 2
+     * Rating 29 String(Nullable Int) - CP Evolved 30 String(Nullable Int) -
+     * Evolvable
+     */
+    private ConfigNew config = ConfigNew.getConfig();
+
+    private  int sortColIndex1, sortColIndex2;
+    private  SortOrder sortOrder1, sortOrder2;
+    
+    private PokemonTableModel ptm;
+
+    public PokemonTable(PokemonGo go) {
+        setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+        setAutoResizeMode(AUTO_RESIZE_OFF);
+        
+        ptm = new PokemonTableModel(go, new ArrayList<Pokemon>(), this);
+        setModel(ptm);
+
+        // Load sort configs
+        sortColIndex1 = config.getInt(ConfigKey.SORT_COLINDEX_1);
+        sortColIndex2 = config.getInt(ConfigKey.SORT_COLINDEX_2);
+        try {
+            sortOrder1 = SortOrder.valueOf(config.getString(ConfigKey.SORT_ORDER_1));
+            sortOrder2 = SortOrder.valueOf(config.getString(ConfigKey.SORT_ORDER_2));
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            sortOrder1 = SortOrder.ASCENDING;
+            sortOrder2 = SortOrder.ASCENDING;
+        }
+        
+        TableRowSorter<TableModel> trs = new TableRowSorter<>(ptm);
+        Comparator<Integer> c = Integer::compareTo;
+        Comparator<Double> cDouble = Double::compareTo;
+        Comparator<String> cDate = (date1, date2) -> DateHelper.fromString(date1)
+                .compareTo(DateHelper.fromString(date2));
+        Comparator<String> cNullableInt = (s1, s2) -> {
+            if ("-".equals(s1))
+                s1 = "0";
+            if ("-".equals(s2))
+                s2 = "0";
+            return Integer.parseInt(s1) - Integer.parseInt(s2);
+        };
+        Comparator<Long> cLong = Long::compareTo;
+        Comparator<String> cPercentageWithTwoCharacters = (s1, s2) -> {
+            int i1 = ("XX".equals(s1)) ? 100 : Integer.parseInt(s1);
+            int i2 = ("XX".equals(s2)) ? 100 : Integer.parseInt(s2);
+            return i1 - i2;
+        };
+        trs.setComparator(0, c);
+        trs.setComparator(3, cPercentageWithTwoCharacters);
+        trs.setComparator(4, cDouble);
+        trs.setComparator(5, c);
+        trs.setComparator(6, c);
+        trs.setComparator(7, c);
+        trs.setComparator(12, c);
+        trs.setComparator(13, c);
+        trs.setComparator(14, c);
+        trs.setComparator(15, c);
+        trs.setComparator(16, c);
+        trs.setComparator(17, c);
+        trs.setComparator(18, c);
+        trs.setComparator(19, cNullableInt);
+        trs.setComparator(20, c);
+        trs.setComparator(22, cDate);
+        trs.setComparator(24, cLong);
+        trs.setComparator(25, cLong);
+        trs.setComparator(26, cLong);
+        trs.setComparator(27, cPercentageWithTwoCharacters);
+        trs.setComparator(28, cPercentageWithTwoCharacters);
+        trs.setComparator(29, cNullableInt);
+        trs.setComparator(30, cNullableInt);
+        setRowSorter(trs);
+        List<SortKey> sortKeys = new ArrayList<>();
+        sortKeys.add(new SortKey(sortColIndex1, sortOrder1));
+        sortKeys.add(new SortKey(sortColIndex2, sortOrder2));
+        trs.setSortKeys(sortKeys);
+
+        // Add listener to save those sorting values
+        trs.addRowSorterListener(
+                e -> {
+                    RowSorter sorter = e.getSource();
+                    if (sorter != null) {
+                        List<SortKey> keys = sorter.getSortKeys();
+                        if (keys.size() > 0) {
+                            SortKey prim = keys.get(0);
+                            sortOrder1 = prim.getSortOrder();
+                            config.setString(ConfigKey.SORT_ORDER_1, sortOrder1.toString());
+                            sortColIndex1 = prim.getColumn();
+                            config.setInt(ConfigKey.SORT_COLINDEX_1, sortColIndex1);
+                        }
+                        if (keys.size() > 1) {
+                            SortKey sec = keys.get(1);
+                            sortOrder2 = sec.getSortOrder();
+                            config.setString(ConfigKey.SORT_ORDER_2, sortOrder2.toString());
+                            sortColIndex2 = sec.getColumn();
+                            config.setInt(ConfigKey.SORT_COLINDEX_2, sortColIndex2);
+                        }
+                    }
+                });
+        
+        // Custom cell renderers
+        // Magic numbers pulled from max values of their respective columns
+        // in the moveset rankings spreadsheet calculations
+        // @see
+        // https://www.reddit.com/r/TheSilphRoad/comments/4vcobt/posthotfix_pokemon_go_full_moveset_rankings/
+        TableColumn duelAbilityCol = getColumnModel().getColumn(24);
+        duelAbilityCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.DUEL_ABILITY_MAX));
+        TableColumn gymAttackCol = getColumnModel().getColumn(25);
+        gymAttackCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_OFFENSE_MAX));
+        TableColumn gymDefenseCol = getColumnModel().getColumn(26);
+        gymDefenseCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_DEFENSE_MAX));
+    }
+    
+
+    public void constructNewTableModel(List<Pokemon> pokes) {
+        ptm.ChangeTableData(pokes);        
+        pack();
+    }
+    
+    private void pack(){
+        for (int ii = 0; ii < ptm.getColumnCount(); ii++) {
+            JTableColumnPacker.packColumn(this, ii, 4);
+        }
+    }
+}

--- a/src/me/corriekay/pokegoutil/utils/windows/PokemonTable.java
+++ b/src/me/corriekay/pokegoutil/utils/windows/PokemonTable.java
@@ -1,0 +1,185 @@
+package me.corriekay.pokegoutil.utils.windows;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import javax.swing.JTable;
+import javax.swing.ListSelectionModel;
+import javax.swing.RowSorter;
+import javax.swing.SortOrder;
+import javax.swing.RowSorter.SortKey;
+import javax.swing.event.TableModelEvent;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableModel;
+import javax.swing.table.TableRowSorter;
+
+import com.pokegoapi.api.PokemonGo;
+import com.pokegoapi.api.pokemon.Pokemon;
+
+import me.corriekay.pokegoutil.utils.ConfigKey;
+import me.corriekay.pokegoutil.utils.ConfigNew;
+import me.corriekay.pokegoutil.utils.helpers.DateHelper;
+import me.corriekay.pokegoutil.utils.helpers.JTableColumnPacker;
+import me.corriekay.pokegoutil.utils.pokemon.PokemonUtils;
+import me.corriekay.pokegoutil.windows.PokemonTab;
+import me.corriekay.pokegoutil.windows.PokemonTab.MoveSetRankingRenderer;
+
+public class PokemonTable extends JTable {
+
+    /**
+     * data types: 0 String - Nickname 1 Integer - Pokemon Number 2 String -
+     * Type / Pokemon 3 String(Percentage) - IV Rating 4 Double - Level 5
+     * Integer - Attack 6 Integer - Defense 7 Integer - Stamina 8 String -
+     * Type 1 9 String - Type 2 10 String - Move 1 11 String - Move 2 12
+     * Integer - CP 13 Integer - HP 14 Integer - Max CP (Current) 15 Integer
+     * - Max CP 16 Integer - Max Evolved CP (Current) 17 Integer - Max
+     * Evolved CP 18 Integer - Candies of type 19 String(Nullable Int) -
+     * Candies to Evolve 20 Integer - Star Dust to level 21 String -
+     * Pokeball Type 22 String(Date) - Caught at 23 Boolean - Favorite 24
+     * Long - duelAbility 25 Integer - gymOffense 26 Integer - gymDefense 27
+     * String(Percentage) - Move 1 Rating 28 String(Percentage) - Move 2
+     * Rating 29 String(Nullable Int) - CP Evolved 30 String(Nullable Int) -
+     * Evolvable
+     */
+    private ConfigNew config = ConfigNew.getConfig();
+
+    private  int sortColIndex1, sortColIndex2;
+    private  SortOrder sortOrder1, sortOrder2;
+    
+    private PokemonTableModel ptm;
+
+    public PokemonTable(PokemonGo go) {
+        setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+        setAutoResizeMode(AUTO_RESIZE_OFF);
+        
+        ptm = new PokemonTableModel(go, new ArrayList<Pokemon>(), this);
+        setModel(ptm);
+
+        // Load sort configs
+        sortColIndex1 = config.getInt(ConfigKey.SORT_COLINDEX_1);
+        sortColIndex2 = config.getInt(ConfigKey.SORT_COLINDEX_2);
+        try {
+            sortOrder1 = SortOrder.valueOf(config.getString(ConfigKey.SORT_ORDER_1));
+            sortOrder2 = SortOrder.valueOf(config.getString(ConfigKey.SORT_ORDER_2));
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            sortOrder1 = SortOrder.ASCENDING;
+            sortOrder2 = SortOrder.ASCENDING;
+        }
+        
+        TableRowSorter<TableModel> trs = new TableRowSorter<>(ptm);
+        Comparator<Integer> c = Integer::compareTo;
+        Comparator<Double> cDouble = Double::compareTo;
+        Comparator<String> cDate = (date1, date2) -> DateHelper.fromString(date1)
+                .compareTo(DateHelper.fromString(date2));
+        Comparator<String> cNullableInt = (s1, s2) -> {
+            if ("-".equals(s1))
+                s1 = "0";
+            if ("-".equals(s2))
+                s2 = "0";
+            return Integer.parseInt(s1) - Integer.parseInt(s2);
+        };
+        Comparator<Long> cLong = Long::compareTo;
+        Comparator<String> cPercentageWithTwoCharacters = (s1, s2) -> {
+            int i1 = ("XX".equals(s1)) ? 100 : Integer.parseInt(s1);
+            int i2 = ("XX".equals(s2)) ? 100 : Integer.parseInt(s2);
+            return i1 - i2;
+        };
+        trs.setComparator(0, c);
+        trs.setComparator(3, cPercentageWithTwoCharacters);
+        trs.setComparator(4, cDouble);
+        trs.setComparator(5, c);
+        trs.setComparator(6, c);
+        trs.setComparator(7, c);
+        trs.setComparator(12, c);
+        trs.setComparator(13, c);
+        trs.setComparator(14, c);
+        trs.setComparator(15, c);
+        trs.setComparator(16, c);
+        trs.setComparator(17, c);
+        trs.setComparator(18, c);
+        trs.setComparator(19, cNullableInt);
+        trs.setComparator(20, c);
+        trs.setComparator(22, cDate);
+        trs.setComparator(24, cLong);
+        trs.setComparator(25, cLong);
+        trs.setComparator(26, cLong);
+        trs.setComparator(27, cPercentageWithTwoCharacters);
+        trs.setComparator(28, cPercentageWithTwoCharacters);
+        trs.setComparator(29, cNullableInt);
+        trs.setComparator(30, cNullableInt);
+        trs.setComparator(31, cLong);
+        trs.setComparator(32, cDouble);
+        trs.setComparator(33, cLong);
+        setRowSorter(trs);
+        List<SortKey> sortKeys = new ArrayList<>();
+        sortKeys.add(new SortKey(sortColIndex1, sortOrder1));
+        sortKeys.add(new SortKey(sortColIndex2, sortOrder2));
+        trs.setSortKeys(sortKeys);
+
+        // Add listener to save those sorting values
+        trs.addRowSorterListener(
+                e -> {
+                    RowSorter sorter = e.getSource();
+                    if (sorter != null) {
+                        List<SortKey> keys = sorter.getSortKeys();
+                        if (keys.size() > 0) {
+                            SortKey prim = keys.get(0);
+                            sortOrder1 = prim.getSortOrder();
+                            config.setString(ConfigKey.SORT_ORDER_1, sortOrder1.toString());
+                            sortColIndex1 = prim.getColumn();
+                            config.setInt(ConfigKey.SORT_COLINDEX_1, sortColIndex1);
+                        }
+                        if (keys.size() > 1) {
+                            SortKey sec = keys.get(1);
+                            sortOrder2 = sec.getSortOrder();
+                            config.setString(ConfigKey.SORT_ORDER_2, sortOrder2.toString());
+                            sortColIndex2 = sec.getColumn();
+                            config.setInt(ConfigKey.SORT_COLINDEX_2, sortColIndex2);
+                        }
+                    }
+                });
+        
+        // Custom cell renderers
+        // Magic numbers pulled from max values of their respective columns
+        // in the moveset rankings spreadsheet calculations
+        // @see
+        // https://www.reddit.com/r/TheSilphRoad/comments/4vcobt/posthotfix_pokemon_go_full_moveset_rankings/
+        TableColumn duelAbilityCol = getColumnModel().getColumn(24);
+        duelAbilityCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.DUEL_ABILITY_MAX));
+        TableColumn gymAttackCol = getColumnModel().getColumn(25);
+        gymAttackCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_OFFENSE_MAX));
+        TableColumn gymDefenseCol = getColumnModel().getColumn(26);
+        gymDefenseCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_DEFENSE_MAX));
+        TableColumn duelAbilityIVCol = getColumnModel().getColumn(31);
+        duelAbilityIVCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.DUEL_ABILITY_IV_MAX));
+        TableColumn gymAttackIVCol = getColumnModel().getColumn(32);
+        gymAttackIVCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_OFFENSE_IV_MAX));
+        TableColumn gymDefenseIVCol = getColumnModel().getColumn(33);
+        gymDefenseIVCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_DEFENSE_IV_MAX));
+        
+        // Magic numbers pulled from max values of their respective columns
+        // in the moveset rankings spreadsheet calculations
+        // @see
+        // https://www.reddit.com/r/TheSilphRoad/comments/4vcobt/posthotfix_pokemon_go_full_moveset_rankings/
+        //TableColumn duelAbilityCol = this.pt.getColumnModel().getColumn(24);
+        //duelAbilityCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.DUEL_ABILITY_MAX));
+        //TableColumn gymAttackCol = this.pt.getColumnModel().getColumn(25);
+        //gymAttackCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_OFFENSE_MAX));
+        //TableColumn gymDefenseCol = this.pt.getColumnModel().getColumn(26);
+        //gymDefenseCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_DEFENSE_MAX));
+    }
+    
+
+    public void constructNewTableModel(List<Pokemon> pokes) {
+        ptm.ChangeTableData(pokes);        
+        pack();
+    }
+    
+    private void pack(){
+        for (int ii = 0; ii < ptm.getColumnCount(); ii++) {
+            JTableColumnPacker.packColumn(this, ii, 4);
+        }
+    }
+}

--- a/src/me/corriekay/pokegoutil/utils/windows/PokemonTable.java
+++ b/src/me/corriekay/pokegoutil/utils/windows/PokemonTable.java
@@ -9,7 +9,6 @@ import javax.swing.ListSelectionModel;
 import javax.swing.RowSorter;
 import javax.swing.SortOrder;
 import javax.swing.RowSorter.SortKey;
-import javax.swing.event.TableModelEvent;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
@@ -22,37 +21,55 @@ import me.corriekay.pokegoutil.utils.ConfigNew;
 import me.corriekay.pokegoutil.utils.helpers.DateHelper;
 import me.corriekay.pokegoutil.utils.helpers.JTableColumnPacker;
 import me.corriekay.pokegoutil.utils.pokemon.PokemonUtils;
-import me.corriekay.pokegoutil.windows.PokemonTab;
 import me.corriekay.pokegoutil.windows.PokemonTab.MoveSetRankingRenderer;
 
+@SuppressWarnings("serial")
 public class PokemonTable extends JTable {
 
-    /**
-     * data types: 0 String - Nickname 1 Integer - Pokemon Number 2 String -
-     * Type / Pokemon 3 String(Percentage) - IV Rating 4 Double - Level 5
-     * Integer - Attack 6 Integer - Defense 7 Integer - Stamina 8 String -
-     * Type 1 9 String - Type 2 10 String - Move 1 11 String - Move 2 12
-     * Integer - CP 13 Integer - HP 14 Integer - Max CP (Current) 15 Integer
-     * - Max CP 16 Integer - Max Evolved CP (Current) 17 Integer - Max
-     * Evolved CP 18 Integer - Candies of type 19 String(Nullable Int) -
-     * Candies to Evolve 20 Integer - Star Dust to level 21 String -
-     * Pokeball Type 22 String(Date) - Caught at 23 Boolean - Favorite 24
-     * Long - duelAbility 25 Integer - gymOffense 26 Integer - gymDefense 27
-     * String(Percentage) - Move 1 Rating 28 String(Percentage) - Move 2
-     * Rating 29 String(Nullable Int) - CP Evolved 30 String(Nullable Int) -
-     * Evolvable
-     */
+    // data types:
+    // 0 String - Nickname
+    // 1 Integer - Pokemon Number
+    // 2 String - Type / Pokemon
+    // 3 String(Percentage) - IV Rating
+    // 4 Double - Level
+    // 5 Integer - Attack
+    // 6 Integer - Defense
+    // 7 Integer - Stamina
+    // 8 String - Type 1
+    // 9 String - Type 2
+    // 10 String - Move 1
+    // 11 String - Move 2
+    // 12 Integer - CP
+    // 13 Integer - HP
+    // 14 Integer - Max CP (Current)
+    // 15 Integer - Max CP
+    // 16 Integer - Max Evolved CP (Current)
+    // 17 Integer - Max Evolved CP
+    // 18 Integer - Candies of type
+    // 19 String(Nullable Int) - Candies to Evolve
+    // 20 Integer Star Dust to level
+    // 21 String - Pokeball Type
+    // 22 String(Date) - Caught at
+    // 23 Boolean - Favorite
+    // 24 Long - duelAbility
+    // 25 Integer - gymOffense
+    // 26 Integer - gymDefense
+    // 27 String(Percentage) Move 1 Rating
+    // 28 String(Percentage) - Move 2 Rating
+    // 29 String(Nullable Int) - CP Evolved
+    // 30 String(Nullable Int) - Evolvable
+
     private ConfigNew config = ConfigNew.getConfig();
 
-    private  int sortColIndex1, sortColIndex2;
-    private  SortOrder sortOrder1, sortOrder2;
-    
+    private int sortColIndex1, sortColIndex2;
+    private SortOrder sortOrder1, sortOrder2;
+
     private PokemonTableModel ptm;
 
     public PokemonTable(PokemonGo go) {
         setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         setAutoResizeMode(AUTO_RESIZE_OFF);
-        
+
         ptm = new PokemonTableModel(go, new ArrayList<Pokemon>(), this);
         setModel(ptm);
 
@@ -67,7 +84,7 @@ public class PokemonTable extends JTable {
             sortOrder1 = SortOrder.ASCENDING;
             sortOrder2 = SortOrder.ASCENDING;
         }
-        
+
         TableRowSorter<TableModel> trs = new TableRowSorter<>(ptm);
         Comparator<Integer> c = Integer::compareTo;
         Comparator<Double> cDouble = Double::compareTo;
@@ -121,9 +138,10 @@ public class PokemonTable extends JTable {
         // Add listener to save those sorting values
         trs.addRowSorterListener(
                 e -> {
-                    RowSorter sorter = e.getSource();
+                    RowSorter<TableModel> sorter = trs;
                     if (sorter != null) {
-                        List<SortKey> keys = sorter.getSortKeys();
+                        @SuppressWarnings("unchecked")
+                        List<SortKey> keys = (List<SortKey>) sorter.getSortKeys();
                         if (keys.size() > 0) {
                             SortKey prim = keys.get(0);
                             sortOrder1 = prim.getSortOrder();
@@ -140,7 +158,7 @@ public class PokemonTable extends JTable {
                         }
                     }
                 });
-        
+
         // Custom cell renderers
         // Magic numbers pulled from max values of their respective columns
         // in the moveset rankings spreadsheet calculations
@@ -170,14 +188,13 @@ public class PokemonTable extends JTable {
         //TableColumn gymDefenseCol = this.pt.getColumnModel().getColumn(26);
         //gymDefenseCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_DEFENSE_MAX));
     }
-    
 
     public void constructNewTableModel(List<Pokemon> pokes) {
-        ptm.ChangeTableData(pokes);        
+        ptm.ChangeTableData(pokes);
         pack();
     }
-    
-    private void pack(){
+
+    private void pack() {
         for (int ii = 0; ii < ptm.getColumnCount(); ii++) {
             JTableColumnPacker.packColumn(this, ii, 4);
         }

--- a/src/me/corriekay/pokegoutil/utils/windows/PokemonTable.java
+++ b/src/me/corriekay/pokegoutil/utils/windows/PokemonTable.java
@@ -9,7 +9,6 @@ import javax.swing.ListSelectionModel;
 import javax.swing.RowSorter;
 import javax.swing.SortOrder;
 import javax.swing.RowSorter.SortKey;
-import javax.swing.event.TableModelEvent;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
@@ -22,37 +21,55 @@ import me.corriekay.pokegoutil.utils.ConfigNew;
 import me.corriekay.pokegoutil.utils.helpers.DateHelper;
 import me.corriekay.pokegoutil.utils.helpers.JTableColumnPacker;
 import me.corriekay.pokegoutil.utils.pokemon.PokemonUtils;
-import me.corriekay.pokegoutil.windows.PokemonTab;
 import me.corriekay.pokegoutil.windows.PokemonTab.MoveSetRankingRenderer;
 
+@SuppressWarnings("serial")
 public class PokemonTable extends JTable {
 
-    /**
-     * data types: 0 String - Nickname 1 Integer - Pokemon Number 2 String -
-     * Type / Pokemon 3 String(Percentage) - IV Rating 4 Double - Level 5
-     * Integer - Attack 6 Integer - Defense 7 Integer - Stamina 8 String -
-     * Type 1 9 String - Type 2 10 String - Move 1 11 String - Move 2 12
-     * Integer - CP 13 Integer - HP 14 Integer - Max CP (Current) 15 Integer
-     * - Max CP 16 Integer - Max Evolved CP (Current) 17 Integer - Max
-     * Evolved CP 18 Integer - Candies of type 19 String(Nullable Int) -
-     * Candies to Evolve 20 Integer - Star Dust to level 21 String -
-     * Pokeball Type 22 String(Date) - Caught at 23 Boolean - Favorite 24
-     * Long - duelAbility 25 Integer - gymOffense 26 Integer - gymDefense 27
-     * String(Percentage) - Move 1 Rating 28 String(Percentage) - Move 2
-     * Rating 29 String(Nullable Int) - CP Evolved 30 String(Nullable Int) -
-     * Evolvable
-     */
+    // data types:
+    // 0 String - Nickname
+    // 1 Integer - Pokemon Number
+    // 2 String - Type / Pokemon
+    // 3 String(Percentage) - IV Rating
+    // 4 Double - Level
+    // 5 Integer - Attack
+    // 6 Integer - Defense
+    // 7 Integer - Stamina
+    // 8 String - Type 1
+    // 9 String - Type 2
+    // 10 String - Move 1
+    // 11 String - Move 2
+    // 12 Integer - CP
+    // 13 Integer - HP
+    // 14 Integer - Max CP (Current)
+    // 15 Integer - Max CP
+    // 16 Integer - Max Evolved CP (Current)
+    // 17 Integer - Max Evolved CP
+    // 18 Integer - Candies of type
+    // 19 String(Nullable Int) - Candies to Evolve
+    // 20 Integer Star Dust to level
+    // 21 String - Pokeball Type
+    // 22 String(Date) - Caught at
+    // 23 Boolean - Favorite
+    // 24 Long - duelAbility
+    // 25 Integer - gymOffense
+    // 26 Integer - gymDefense
+    // 27 String(Percentage) Move 1 Rating
+    // 28 String(Percentage) - Move 2 Rating
+    // 29 String(Nullable Int) - CP Evolved
+    // 30 String(Nullable Int) - Evolvable
+
     private ConfigNew config = ConfigNew.getConfig();
 
-    private  int sortColIndex1, sortColIndex2;
-    private  SortOrder sortOrder1, sortOrder2;
-    
+    private int sortColIndex1, sortColIndex2;
+    private SortOrder sortOrder1, sortOrder2;
+
     private PokemonTableModel ptm;
 
     public PokemonTable(PokemonGo go) {
         setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         setAutoResizeMode(AUTO_RESIZE_OFF);
-        
+
         ptm = new PokemonTableModel(go, new ArrayList<Pokemon>(), this);
         setModel(ptm);
 
@@ -67,7 +84,7 @@ public class PokemonTable extends JTable {
             sortOrder1 = SortOrder.ASCENDING;
             sortOrder2 = SortOrder.ASCENDING;
         }
-        
+
         TableRowSorter<TableModel> trs = new TableRowSorter<>(ptm);
         Comparator<Integer> c = Integer::compareTo;
         Comparator<Double> cDouble = Double::compareTo;
@@ -118,9 +135,10 @@ public class PokemonTable extends JTable {
         // Add listener to save those sorting values
         trs.addRowSorterListener(
                 e -> {
-                    RowSorter sorter = e.getSource();
+                    RowSorter<TableModel> sorter = trs;
                     if (sorter != null) {
-                        List<SortKey> keys = sorter.getSortKeys();
+                        @SuppressWarnings("unchecked")
+                        List<SortKey> keys = (List<SortKey>) sorter.getSortKeys();
                         if (keys.size() > 0) {
                             SortKey prim = keys.get(0);
                             sortOrder1 = prim.getSortOrder();
@@ -137,7 +155,7 @@ public class PokemonTable extends JTable {
                         }
                     }
                 });
-        
+
         // Custom cell renderers
         // Magic numbers pulled from max values of their respective columns
         // in the moveset rankings spreadsheet calculations
@@ -150,14 +168,13 @@ public class PokemonTable extends JTable {
         TableColumn gymDefenseCol = getColumnModel().getColumn(26);
         gymDefenseCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_DEFENSE_MAX));
     }
-    
 
     public void constructNewTableModel(List<Pokemon> pokes) {
-        ptm.ChangeTableData(pokes);        
+        ptm.ChangeTableData(pokes);
         pack();
     }
-    
-    private void pack(){
+
+    private void pack() {
         for (int ii = 0; ii < ptm.getColumnCount(); ii++) {
             JTableColumnPacker.packColumn(this, ii, 4);
         }

--- a/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
+++ b/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
@@ -27,39 +27,13 @@ import me.corriekay.pokegoutil.utils.pokemon.PokeHandler;
 import me.corriekay.pokegoutil.utils.pokemon.PokemonCpUtils;
 import me.corriekay.pokegoutil.utils.pokemon.PokemonUtils;
 
-@SuppressWarnings({"serial","rawtypes"})
+@SuppressWarnings({ "serial", "rawtypes" })
 
 public class PokemonTableModel extends AbstractTableModel {
 
     PokemonTable pt;
 
     private ArrayList<Pokemon> pokeCol = new ArrayList<>();
-    /*
-     * private ArrayList<Integer> numIdCol = new ArrayList<>();// 0 private
-     * ArrayList<String> nickCol = new ArrayList<>(), // 1 speciesCol = new
-     * ArrayList<>(), // 2 ivCol = new ArrayList<>();// 3 private
-     * ArrayList<Double> levelCol = new ArrayList<>();// 4 private
-     * ArrayList<Integer> atkCol = new ArrayList<>(), // 5 defCol = new
-     * ArrayList<>(), // 6 stamCol = new ArrayList<>();// 7 private
-     * ArrayList<String> type1Col = new ArrayList<>(), // 8 type2Col = new
-     * ArrayList<>(), // 9 move1Col = new ArrayList<>(), // 10 move2Col = new
-     * ArrayList<>();// 11 private ArrayList<Integer> cpCol = new ArrayList<>(),
-     * // 12 hpCol = new ArrayList<>(), // 13 maxCpCurrentCol = new
-     * ArrayList<>(), // 14 maxCpCol = new ArrayList<>(), // 15
-     * maxEvolvedCpCurrentCol = new ArrayList<>(), // 16 maxEvolvedCpCol = new
-     * ArrayList<>(), // 17 candiesCol = new ArrayList<>();// 18 private
-     * ArrayList<String> candies2EvlvCol = new ArrayList<>();// 19 private
-     * ArrayList<Integer> dustToLevelCol = new ArrayList<>();// 20 private
-     * ArrayList<String> pokeballCol = new ArrayList<>(), // 21 caughtCol = new
-     * ArrayList<>(), // 22 favCol = new ArrayList<>();// 23 private
-     * ArrayList<Long> duelAbilityCol = new ArrayList<>();// 24 private
-     * ArrayList<Long> gymOffenseCol = new ArrayList<>();// 25 private
-     * ArrayList<Long> gymDefenseCol = new ArrayList<>();// 26 private
-     * ArrayList<String> move1RatingCol = new ArrayList<>(), // 27
-     * move2RatingCol = new ArrayList<>();// 28 private ArrayList<String>
-     * cpEvolvedCol = new ArrayList<>(), // 29 evolvableCol = new
-     * ArrayList<>();// 30
-     */
     private PokemonGo go;
 
     private ArrayList<AbstractMap.SimpleEntry<String, ArrayList>> data;
@@ -69,50 +43,42 @@ public class PokemonTableModel extends AbstractTableModel {
         this.pt = pt;
         this.go = go;
 
-        data = new ArrayList<AbstractMap.SimpleEntry<String,ArrayList>>();
-        
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Id", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Nickname", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Species", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("IV %", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Lvl", new ArrayList<Double>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Atk", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Def", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Stam", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Type 1", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Type 2", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 1", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 2", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("CP", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("HP", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max CP (Cur)", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max CP (40)", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max Evolved CP (Cur)",
-                new ArrayList<Integer>()));
-        data.add(
-                new AbstractMap.SimpleEntry<String, ArrayList>("Max Evolved CP (40)", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Candies", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("To Evolve", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Stardust", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Caught With", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Time Caught", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Favorite", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Duel Ability", new ArrayList<Long>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Offense", new ArrayList<Long>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Defense", new ArrayList<Long>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 1 Rating", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 2 Rating", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("CP Evolved", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Evolvable", new ArrayList<String>()));
-        
+        data = new ArrayList<AbstractMap.SimpleEntry<String, ArrayList>>();
+
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Id", new ArrayList<Integer>())); // 0
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Nickname", new ArrayList<String>()));// 1
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Species", new ArrayList<String>()));// 2
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("IV %", new ArrayList<String>()));// 3
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Lvl", new ArrayList<Double>()));// 4
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Atk", new ArrayList<Integer>()));// 5
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Def", new ArrayList<Integer>()));// 6
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Stam", new ArrayList<Integer>()));// 7
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Type 1", new ArrayList<String>()));// 8
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Type 2", new ArrayList<String>()));// 9
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 1", new ArrayList<String>()));// 10
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 2", new ArrayList<String>()));// 11
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("CP", new ArrayList<Integer>()));// 12
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("HP", new ArrayList<Integer>()));// 13
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max CP (Cur)", new ArrayList<Integer>()));// 14
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max CP (40)", new ArrayList<Integer>()));// 15
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max Evolved CP (Cur)", new ArrayList<Integer>()));// 16
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max Evolved CP (40)", new ArrayList<Integer>()));// 17
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Candies", new ArrayList<Integer>()));// 18
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("To Evolve", new ArrayList<String>()));// 19
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Stardust", new ArrayList<Integer>()));// 20
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Caught With", new ArrayList<String>()));// 21
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Time Caught", new ArrayList<String>()));// 22
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Favorite", new ArrayList<String>()));// 23
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Duel Ability", new ArrayList<Long>()));// 24
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Offense", new ArrayList<Long>()));// 25
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Defense", new ArrayList<Long>()));// 26
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 1 Rating", new ArrayList<String>()));// 27
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 2 Rating", new ArrayList<String>()));// 28
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("CP Evolved", new ArrayList<String>()));// 29
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Evolvable", new ArrayList<String>()));// 30
+
         ChangeTableData(pokes);
     }
-
-    // private AbstractMap.SimpleEntry<String,ArrayList> CreateEntry(String
-    // key){
-    // return new AbstractMap.SimpleEntry<String, ArrayList>(key, new
-    // ArrayList<>());
-    // }
 
     private ArrayList getColumnList(int columnIndex) {
         return data.get(columnIndex).getValue();
@@ -126,29 +92,30 @@ public class PokemonTableModel extends AbstractTableModel {
 
         pokes.forEach(p -> {
             pokeCol.add(i.getValue(), p);
-            getColumnList(0).add(i.getValue(),p.getMeta().getNumber());
-            getColumnList(1).add(i.getValue(),p.getNickname());
-            getColumnList(2).add(i.getValue(),PokeHandler.getLocalPokeName(p));            
-            getColumnList(3).add(i.getValue(),Utilities.percentageWithTwoCharacters(PokemonUtils.ivRating(p)));
-            getColumnList(4).add(i.getValue(),p.getLevel());
-            getColumnList(12).add(i.getValue(),p.getCp());
-            getColumnList(5).add(i.getValue(),p.getIndividualAttack());
-            getColumnList(6).add(i.getValue(),p.getIndividualDefense());
-            getColumnList(7).add(i.getValue(),p.getIndividualStamina());
-            getColumnList(8).add(i.getValue(),StringUtils.capitalize(p.getMeta().getType1().toString().toLowerCase()));
-            getColumnList(9).add(i.getValue(),StringUtils.capitalize(
+            getColumnList(0).add(i.getValue(), p.getMeta().getNumber());
+            getColumnList(1).add(i.getValue(), p.getNickname());
+            getColumnList(2).add(i.getValue(), PokeHandler.getLocalPokeName(p));
+            getColumnList(3).add(i.getValue(), Utilities.percentageWithTwoCharacters(PokemonUtils.ivRating(p)));
+            getColumnList(4).add(i.getValue(), p.getLevel());
+            getColumnList(12).add(i.getValue(), p.getCp());
+            getColumnList(5).add(i.getValue(), p.getIndividualAttack());
+            getColumnList(6).add(i.getValue(), p.getIndividualDefense());
+            getColumnList(7).add(i.getValue(), p.getIndividualStamina());
+            getColumnList(8).add(i.getValue(), StringUtils.capitalize(p.getMeta().getType1().toString().toLowerCase()));
+            getColumnList(9).add(i.getValue(), StringUtils.capitalize(
                     p.getMeta().getType2().toString().toLowerCase().replaceAll("none", "")));
 
             Double dps1 = PokemonUtils.dpsForMove(p, true);
             Double dps2 = PokemonUtils.dpsForMove(p, false);
 
-            getColumnList(10).add(i.getValue(),WordUtils.capitalize(
+            getColumnList(10).add(i.getValue(), WordUtils.capitalize(
                     p.getMove1().toString().toLowerCase().replaceAll("_fast", "").replaceAll("_", " "))
                     + " (" + String.format("%.2f", dps1) + "dps)");
             getColumnList(11)
-                    .add(i.getValue(),WordUtils.capitalize(p.getMove2().toString().toLowerCase().replaceAll("_", " ")) + " ("
-                            + String.format("%.2f", dps2) + "dps)");
-            getColumnList(13).add(i.getValue(),p.getMaxStamina());
+                    .add(i.getValue(),
+                            WordUtils.capitalize(p.getMove2().toString().toLowerCase().replaceAll("_", " ")) + " ("
+                                    + String.format("%.2f", dps2) + "dps)");
+            getColumnList(13).add(i.getValue(), p.getMaxStamina());
 
             int trainerLevel = 1;
             try {
@@ -168,8 +135,8 @@ public class PokemonTableModel extends AbstractTableModel {
                 int stamina = p.getIndividualStamina() + pokemonMeta.getBaseStamina();
                 maxCpCurrent = PokemonCpUtils.getMaxCpForTrainerLevel(attack, defense, stamina, trainerLevel);
                 maxCp = PokemonCpUtils.getMaxCp(attack, defense, stamina);
-                getColumnList(14).add(i.getValue(),maxCpCurrent);
-                getColumnList(15).add(i.getValue(),maxCp);
+                getColumnList(14).add(i.getValue(), maxCpCurrent);
+                getColumnList(15).add(i.getValue(), maxCp);
             }
 
             // Max CP calculation for highest evolution of current Pokemon
@@ -204,9 +171,9 @@ public class PokemonTableModel extends AbstractTableModel {
 
             PokemonMeta highestFamilyMeta = PokemonMetaRegistry.getMeta(highestFamilyId);
             if (highestFamilyId == p.getPokemonId()) {
-                getColumnList(16).add(i.getValue(),maxCpCurrent);
-                getColumnList(17).add(i.getValue(),maxCp);
-                getColumnList(29).add(i.getValue(),"-");
+                getColumnList(16).add(i.getValue(), maxCpCurrent);
+                getColumnList(17).add(i.getValue(), maxCp);
+                getColumnList(29).add(i.getValue(), "-");
             } else if (highestFamilyMeta == null) {
                 System.out.println("Error: Cannot find meta data for " + highestFamilyId.name());
             } else {
@@ -214,40 +181,41 @@ public class PokemonTableModel extends AbstractTableModel {
                 int defense = highestFamilyMeta.getBaseDefense() + p.getIndividualDefense();
                 int stamina = highestFamilyMeta.getBaseStamina() + p.getIndividualStamina();
 
-                getColumnList(16).add(i.getValue(),PokemonCpUtils.getMaxCpForTrainerLevel(attack, defense, stamina, trainerLevel));
-                getColumnList(17).add(i.getValue(),PokemonCpUtils.getMaxCp(attack, defense, stamina));
-                getColumnList(29).add(i.getValue(),String
+                getColumnList(16).add(i.getValue(),
+                        PokemonCpUtils.getMaxCpForTrainerLevel(attack, defense, stamina, trainerLevel));
+                getColumnList(17).add(i.getValue(), PokemonCpUtils.getMaxCp(attack, defense, stamina));
+                getColumnList(29).add(i.getValue(), String
                         .valueOf(PokemonCpUtils.getCpForPokemonLevel(attack, defense, stamina, p.getLevel())));
             }
 
             int candies = 0;
             try {
                 candies = p.getCandy();
-                getColumnList(18).add(i.getValue(),candies);
-                
+                getColumnList(18).add(i.getValue(), candies);
+
             } catch (Exception e) {
                 e.printStackTrace();
             }
             if (p.getCandiesToEvolve() != 0) {
-                getColumnList(19).add(i.getValue(),String.valueOf(p.getCandiesToEvolve()));
-                getColumnList(30).add(i.getValue(),String.valueOf(GetEvolvable(candies, p.getCandiesToEvolve())));
+                getColumnList(19).add(i.getValue(), String.valueOf(p.getCandiesToEvolve()));
+                getColumnList(30).add(i.getValue(), String.valueOf(GetEvolvable(candies, p.getCandiesToEvolve())));
             } else {
-                getColumnList(19).add(i.getValue(),"-");
-                getColumnList(30).add(i.getValue(),"-");
+                getColumnList(19).add(i.getValue(), "-");
+                getColumnList(30).add(i.getValue(), "-");
             }
-            getColumnList(20).add(i.getValue(),p.getStardustCostsForPowerup());
-            getColumnList(21).add(i.getValue(),WordUtils.capitalize(
+            getColumnList(20).add(i.getValue(), p.getStardustCostsForPowerup());
+            getColumnList(21).add(i.getValue(), WordUtils.capitalize(
                     p.getPokeball().toString().toLowerCase().replaceAll("item_", "").replaceAll("_", " ")));
-            getColumnList(22).add(i.getValue(),DateHelper.toString(DateHelper.fromTimestamp(p.getCreationTimeMs())));
+            getColumnList(22).add(i.getValue(), DateHelper.toString(DateHelper.fromTimestamp(p.getCreationTimeMs())));
             getColumnList(23).add(i.getValue(), (p.isFavorite()) ? "True" : "");
-            getColumnList(24).add(i.getValue(),PokemonUtils.duelAbility(p));
-            getColumnList(25).add(i.getValue(),PokemonUtils.gymOffense(p));
-            getColumnList(26).add(i.getValue(),PokemonUtils.gymDefense(p));
-            getColumnList(27).add(i.getValue(),PokemonUtils.moveRating(p, true));
-            getColumnList(28).add(i.getValue(),PokemonUtils.moveRating(p, false));
+            getColumnList(24).add(i.getValue(), PokemonUtils.duelAbility(p));
+            getColumnList(25).add(i.getValue(), PokemonUtils.gymOffense(p));
+            getColumnList(26).add(i.getValue(), PokemonUtils.gymDefense(p));
+            getColumnList(27).add(i.getValue(), PokemonUtils.moveRating(p, true));
+            getColumnList(28).add(i.getValue(), PokemonUtils.moveRating(p, false));
             i.increment();
         });
-        
+
         fireTableDataChanged();
     }
 

--- a/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
+++ b/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
@@ -27,39 +27,13 @@ import me.corriekay.pokegoutil.utils.pokemon.PokeHandler;
 import me.corriekay.pokegoutil.utils.pokemon.PokemonCpUtils;
 import me.corriekay.pokegoutil.utils.pokemon.PokemonUtils;
 
-@SuppressWarnings({"serial","rawtypes"})
+@SuppressWarnings({ "serial", "rawtypes" })
 
 public class PokemonTableModel extends AbstractTableModel {
 
     PokemonTable pt;
 
     private ArrayList<Pokemon> pokeCol = new ArrayList<>();
-    /*
-     * private ArrayList<Integer> numIdCol = new ArrayList<>();// 0 private
-     * ArrayList<String> nickCol = new ArrayList<>(), // 1 speciesCol = new
-     * ArrayList<>(), // 2 ivCol = new ArrayList<>();// 3 private
-     * ArrayList<Double> levelCol = new ArrayList<>();// 4 private
-     * ArrayList<Integer> atkCol = new ArrayList<>(), // 5 defCol = new
-     * ArrayList<>(), // 6 stamCol = new ArrayList<>();// 7 private
-     * ArrayList<String> type1Col = new ArrayList<>(), // 8 type2Col = new
-     * ArrayList<>(), // 9 move1Col = new ArrayList<>(), // 10 move2Col = new
-     * ArrayList<>();// 11 private ArrayList<Integer> cpCol = new ArrayList<>(),
-     * // 12 hpCol = new ArrayList<>(), // 13 maxCpCurrentCol = new
-     * ArrayList<>(), // 14 maxCpCol = new ArrayList<>(), // 15
-     * maxEvolvedCpCurrentCol = new ArrayList<>(), // 16 maxEvolvedCpCol = new
-     * ArrayList<>(), // 17 candiesCol = new ArrayList<>();// 18 private
-     * ArrayList<String> candies2EvlvCol = new ArrayList<>();// 19 private
-     * ArrayList<Integer> dustToLevelCol = new ArrayList<>();// 20 private
-     * ArrayList<String> pokeballCol = new ArrayList<>(), // 21 caughtCol = new
-     * ArrayList<>(), // 22 favCol = new ArrayList<>();// 23 private
-     * ArrayList<Long> duelAbilityCol = new ArrayList<>();// 24 private
-     * ArrayList<Long> gymOffenseCol = new ArrayList<>();// 25 private
-     * ArrayList<Long> gymDefenseCol = new ArrayList<>();// 26 private
-     * ArrayList<String> move1RatingCol = new ArrayList<>(), // 27
-     * move2RatingCol = new ArrayList<>();// 28 private ArrayList<String>
-     * cpEvolvedCol = new ArrayList<>(), // 29 evolvableCol = new
-     * ArrayList<>();// 30
-     */
     private PokemonGo go;
 
     private ArrayList<AbstractMap.SimpleEntry<String, ArrayList>> data;
@@ -69,53 +43,45 @@ public class PokemonTableModel extends AbstractTableModel {
         this.pt = pt;
         this.go = go;
 
-        data = new ArrayList<AbstractMap.SimpleEntry<String,ArrayList>>();
-        
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Id", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Nickname", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Species", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("IV %", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Lvl", new ArrayList<Double>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Atk", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Def", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Stam", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Type 1", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Type 2", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 1", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 2", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("CP", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("HP", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max CP (Cur)", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max CP (40)", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max Evolved CP (Cur)",
-                new ArrayList<Integer>()));
-        data.add(
-                new AbstractMap.SimpleEntry<String, ArrayList>("Max Evolved CP (40)", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Candies", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("To Evolve", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Stardust", new ArrayList<Integer>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Caught With", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Time Caught", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Favorite", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Duel Ability", new ArrayList<Long>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Offense", new ArrayList<Long>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Defense", new ArrayList<Long>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 1 Rating", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 2 Rating", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("CP Evolved", new ArrayList<String>()));
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Evolvable", new ArrayList<String>()));
+        data = new ArrayList<AbstractMap.SimpleEntry<String, ArrayList>>();
+
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Id", new ArrayList<Integer>())); // 0
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Nickname", new ArrayList<String>()));// 1
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Species", new ArrayList<String>()));// 2
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("IV %", new ArrayList<String>()));// 3
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Lvl", new ArrayList<Double>()));// 4
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Atk", new ArrayList<Integer>()));// 5
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Def", new ArrayList<Integer>()));// 6
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Stam", new ArrayList<Integer>()));// 7
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Type 1", new ArrayList<String>()));// 8
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Type 2", new ArrayList<String>()));// 9
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 1", new ArrayList<String>()));// 10
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 2", new ArrayList<String>()));// 11
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("CP", new ArrayList<Integer>()));// 12
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("HP", new ArrayList<Integer>()));// 13
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max CP (Cur)", new ArrayList<Integer>()));// 14
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max CP (40)", new ArrayList<Integer>()));// 15
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max Evolved CP (Cur)", new ArrayList<Integer>()));// 16
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max Evolved CP (40)", new ArrayList<Integer>()));// 17
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Candies", new ArrayList<Integer>()));// 18
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("To Evolve", new ArrayList<String>()));// 19
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Stardust", new ArrayList<Integer>()));// 20
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Caught With", new ArrayList<String>()));// 21
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Time Caught", new ArrayList<String>()));// 22
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Favorite", new ArrayList<String>()));// 23
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Duel Ability", new ArrayList<Long>()));// 24
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Offense", new ArrayList<Long>()));// 25
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Defense", new ArrayList<Long>()));// 26
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 1 Rating", new ArrayList<String>()));// 27
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 2 Rating", new ArrayList<String>()));// 28
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("CP Evolved", new ArrayList<String>()));// 29
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Evolvable", new ArrayList<String>()));// 30
         data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Duel Ability IV", new ArrayList<Long>()));
         data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Offense IV", new ArrayList<Double>()));
         data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Defense IV", new ArrayList<Long>()));
       
         ChangeTableData(pokes);
     }
-
-    // private AbstractMap.SimpleEntry<String,ArrayList> CreateEntry(String
-    // key){
-    // return new AbstractMap.SimpleEntry<String, ArrayList>(key, new
-    // ArrayList<>());
-    // }
 
     private ArrayList getColumnList(int columnIndex) {
         return data.get(columnIndex).getValue();
@@ -129,29 +95,30 @@ public class PokemonTableModel extends AbstractTableModel {
 
         pokes.forEach(p -> {
             pokeCol.add(i.getValue(), p);
-            getColumnList(0).add(i.getValue(),p.getMeta().getNumber());
-            getColumnList(1).add(i.getValue(),p.getNickname());
-            getColumnList(2).add(i.getValue(),PokeHandler.getLocalPokeName(p));            
-            getColumnList(3).add(i.getValue(),Utilities.percentageWithTwoCharacters(PokemonUtils.ivRating(p)));
-            getColumnList(4).add(i.getValue(),p.getLevel());
-            getColumnList(12).add(i.getValue(),p.getCp());
-            getColumnList(5).add(i.getValue(),p.getIndividualAttack());
-            getColumnList(6).add(i.getValue(),p.getIndividualDefense());
-            getColumnList(7).add(i.getValue(),p.getIndividualStamina());
-            getColumnList(8).add(i.getValue(),StringUtils.capitalize(p.getMeta().getType1().toString().toLowerCase()));
-            getColumnList(9).add(i.getValue(),StringUtils.capitalize(
+            getColumnList(0).add(i.getValue(), p.getMeta().getNumber());
+            getColumnList(1).add(i.getValue(), p.getNickname());
+            getColumnList(2).add(i.getValue(), PokeHandler.getLocalPokeName(p));
+            getColumnList(3).add(i.getValue(), Utilities.percentageWithTwoCharacters(PokemonUtils.ivRating(p)));
+            getColumnList(4).add(i.getValue(), p.getLevel());
+            getColumnList(12).add(i.getValue(), p.getCp());
+            getColumnList(5).add(i.getValue(), p.getIndividualAttack());
+            getColumnList(6).add(i.getValue(), p.getIndividualDefense());
+            getColumnList(7).add(i.getValue(), p.getIndividualStamina());
+            getColumnList(8).add(i.getValue(), StringUtils.capitalize(p.getMeta().getType1().toString().toLowerCase()));
+            getColumnList(9).add(i.getValue(), StringUtils.capitalize(
                     p.getMeta().getType2().toString().toLowerCase().replaceAll("none", "")));
 
             Double dps1 = PokemonUtils.dpsForMove(p, true);
             Double dps2 = PokemonUtils.dpsForMove(p, false);
 
-            getColumnList(10).add(i.getValue(),WordUtils.capitalize(
+            getColumnList(10).add(i.getValue(), WordUtils.capitalize(
                     p.getMove1().toString().toLowerCase().replaceAll("_fast", "").replaceAll("_", " "))
                     + " (" + String.format("%.2f", dps1) + "dps)");
             getColumnList(11)
-                    .add(i.getValue(),WordUtils.capitalize(p.getMove2().toString().toLowerCase().replaceAll("_", " ")) + " ("
-                            + String.format("%.2f", dps2) + "dps)");
-            getColumnList(13).add(i.getValue(),p.getMaxStamina());
+                    .add(i.getValue(),
+                            WordUtils.capitalize(p.getMove2().toString().toLowerCase().replaceAll("_", " ")) + " ("
+                                    + String.format("%.2f", dps2) + "dps)");
+            getColumnList(13).add(i.getValue(), p.getMaxStamina());
 
             int trainerLevel = 1;
             try {
@@ -171,8 +138,8 @@ public class PokemonTableModel extends AbstractTableModel {
                 int stamina = p.getIndividualStamina() + pokemonMeta.getBaseStamina();
                 maxCpCurrent = PokemonCpUtils.getMaxCpForTrainerLevel(attack, defense, stamina, trainerLevel);
                 maxCp = PokemonCpUtils.getMaxCp(attack, defense, stamina);
-                getColumnList(14).add(i.getValue(),maxCpCurrent);
-                getColumnList(15).add(i.getValue(),maxCp);
+                getColumnList(14).add(i.getValue(), maxCpCurrent);
+                getColumnList(15).add(i.getValue(), maxCp);
             }
 
             // Max CP calculation for highest evolution of current Pokemon
@@ -207,9 +174,9 @@ public class PokemonTableModel extends AbstractTableModel {
 
             PokemonMeta highestFamilyMeta = PokemonMetaRegistry.getMeta(highestFamilyId);
             if (highestFamilyId == p.getPokemonId()) {
-                getColumnList(16).add(i.getValue(),maxCpCurrent);
-                getColumnList(17).add(i.getValue(),maxCp);
-                getColumnList(29).add(i.getValue(),"-");
+                getColumnList(16).add(i.getValue(), maxCpCurrent);
+                getColumnList(17).add(i.getValue(), maxCp);
+                getColumnList(29).add(i.getValue(), "-");
             } else if (highestFamilyMeta == null) {
                 System.out.println("Error: Cannot find meta data for " + highestFamilyId.name());
             } else {
@@ -217,31 +184,32 @@ public class PokemonTableModel extends AbstractTableModel {
                 int defense = highestFamilyMeta.getBaseDefense() + p.getIndividualDefense();
                 int stamina = highestFamilyMeta.getBaseStamina() + p.getIndividualStamina();
 
-                getColumnList(16).add(i.getValue(),PokemonCpUtils.getMaxCpForTrainerLevel(attack, defense, stamina, trainerLevel));
-                getColumnList(17).add(i.getValue(),PokemonCpUtils.getMaxCp(attack, defense, stamina));
-                getColumnList(29).add(i.getValue(),String
+                getColumnList(16).add(i.getValue(),
+                        PokemonCpUtils.getMaxCpForTrainerLevel(attack, defense, stamina, trainerLevel));
+                getColumnList(17).add(i.getValue(), PokemonCpUtils.getMaxCp(attack, defense, stamina));
+                getColumnList(29).add(i.getValue(), String
                         .valueOf(PokemonCpUtils.getCpForPokemonLevel(attack, defense, stamina, p.getLevel())));
             }
 
             int candies = 0;
             try {
                 candies = p.getCandy();
-                getColumnList(18).add(i.getValue(),candies);
-                
+                getColumnList(18).add(i.getValue(), candies);
+
             } catch (Exception e) {
                 e.printStackTrace();
             }
             if (p.getCandiesToEvolve() != 0) {
-                getColumnList(19).add(i.getValue(),String.valueOf(p.getCandiesToEvolve()));
-                getColumnList(30).add(i.getValue(),String.valueOf(GetEvolvable(candies, p.getCandiesToEvolve())));
+                getColumnList(19).add(i.getValue(), String.valueOf(p.getCandiesToEvolve()));
+                getColumnList(30).add(i.getValue(), String.valueOf(GetEvolvable(candies, p.getCandiesToEvolve())));
             } else {
-                getColumnList(19).add(i.getValue(),"-");
-                getColumnList(30).add(i.getValue(),"-");
+                getColumnList(19).add(i.getValue(), "-");
+                getColumnList(30).add(i.getValue(), "-");
             }
-            getColumnList(20).add(i.getValue(),p.getStardustCostsForPowerup());
-            getColumnList(21).add(i.getValue(),WordUtils.capitalize(
+            getColumnList(20).add(i.getValue(), p.getStardustCostsForPowerup());
+            getColumnList(21).add(i.getValue(), WordUtils.capitalize(
                     p.getPokeball().toString().toLowerCase().replaceAll("item_", "").replaceAll("_", " ")));
-            getColumnList(22).add(i.getValue(),DateHelper.toString(DateHelper.fromTimestamp(p.getCreationTimeMs())));
+            getColumnList(22).add(i.getValue(), DateHelper.toString(DateHelper.fromTimestamp(p.getCreationTimeMs())));
             getColumnList(23).add(i.getValue(), (p.isFavorite()) ? "True" : "");
             getColumnList(24).add(i.getValue(),PokemonUtils.duelAbility(p, false));
             getColumnList(25).add(i.getValue(),PokemonUtils.gymOffense(p, false));
@@ -254,7 +222,7 @@ public class PokemonTableModel extends AbstractTableModel {
             
             i.increment();
         });
-        
+
         fireTableDataChanged();
     }
 

--- a/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
+++ b/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
@@ -1,0 +1,295 @@
+package me.corriekay.pokegoutil.utils.windows;
+
+import java.util.AbstractMap;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import javax.swing.table.AbstractTableModel;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.commons.lang3.text.WordUtils;
+
+import com.pokegoapi.api.PokemonGo;
+import com.pokegoapi.api.pokemon.Pokemon;
+import com.pokegoapi.api.pokemon.PokemonMeta;
+import com.pokegoapi.api.pokemon.PokemonMetaRegistry;
+
+import POGOProtos.Enums.PokemonFamilyIdOuterClass.PokemonFamilyId;
+import POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
+import me.corriekay.pokegoutil.utils.Utilities;
+import me.corriekay.pokegoutil.utils.helpers.DateHelper;
+import me.corriekay.pokegoutil.utils.pokemon.PokeHandler;
+import me.corriekay.pokegoutil.utils.pokemon.PokemonCpUtils;
+import me.corriekay.pokegoutil.utils.pokemon.PokemonUtils;
+
+@SuppressWarnings({"serial","rawtypes"})
+
+public class PokemonTableModel extends AbstractTableModel {
+
+    PokemonTable pt;
+
+    private ArrayList<Pokemon> pokeCol = new ArrayList<>();
+    /*
+     * private ArrayList<Integer> numIdCol = new ArrayList<>();// 0 private
+     * ArrayList<String> nickCol = new ArrayList<>(), // 1 speciesCol = new
+     * ArrayList<>(), // 2 ivCol = new ArrayList<>();// 3 private
+     * ArrayList<Double> levelCol = new ArrayList<>();// 4 private
+     * ArrayList<Integer> atkCol = new ArrayList<>(), // 5 defCol = new
+     * ArrayList<>(), // 6 stamCol = new ArrayList<>();// 7 private
+     * ArrayList<String> type1Col = new ArrayList<>(), // 8 type2Col = new
+     * ArrayList<>(), // 9 move1Col = new ArrayList<>(), // 10 move2Col = new
+     * ArrayList<>();// 11 private ArrayList<Integer> cpCol = new ArrayList<>(),
+     * // 12 hpCol = new ArrayList<>(), // 13 maxCpCurrentCol = new
+     * ArrayList<>(), // 14 maxCpCol = new ArrayList<>(), // 15
+     * maxEvolvedCpCurrentCol = new ArrayList<>(), // 16 maxEvolvedCpCol = new
+     * ArrayList<>(), // 17 candiesCol = new ArrayList<>();// 18 private
+     * ArrayList<String> candies2EvlvCol = new ArrayList<>();// 19 private
+     * ArrayList<Integer> dustToLevelCol = new ArrayList<>();// 20 private
+     * ArrayList<String> pokeballCol = new ArrayList<>(), // 21 caughtCol = new
+     * ArrayList<>(), // 22 favCol = new ArrayList<>();// 23 private
+     * ArrayList<Long> duelAbilityCol = new ArrayList<>();// 24 private
+     * ArrayList<Long> gymOffenseCol = new ArrayList<>();// 25 private
+     * ArrayList<Long> gymDefenseCol = new ArrayList<>();// 26 private
+     * ArrayList<String> move1RatingCol = new ArrayList<>(), // 27
+     * move2RatingCol = new ArrayList<>();// 28 private ArrayList<String>
+     * cpEvolvedCol = new ArrayList<>(), // 29 evolvableCol = new
+     * ArrayList<>();// 30
+     */
+    private PokemonGo go;
+
+    private ArrayList<AbstractMap.SimpleEntry<String, ArrayList>> data;
+
+    @Deprecated
+    PokemonTableModel(PokemonGo go, List<Pokemon> pokes, PokemonTable pt) {
+        this.pt = pt;
+        this.go = go;
+
+        data = new ArrayList<AbstractMap.SimpleEntry<String,ArrayList>>();
+        
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Id", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Nickname", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Species", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("IV %", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Lvl", new ArrayList<Double>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Atk", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Def", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Stam", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Type 1", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Type 2", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 1", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 2", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("CP", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("HP", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max CP (Cur)", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max CP (40)", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max Evolved CP (Cur)",
+                new ArrayList<Integer>()));
+        data.add(
+                new AbstractMap.SimpleEntry<String, ArrayList>("Max Evolved CP (40)", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Candies", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("To Evolve", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Stardust", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Caught With", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Time Caught", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Favorite", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Duel Ability", new ArrayList<Long>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Offense", new ArrayList<Long>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Defense", new ArrayList<Long>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 1 Rating", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 2 Rating", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("CP Evolved", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Evolvable", new ArrayList<String>()));
+        
+        ChangeTableData(pokes);
+    }
+
+    // private AbstractMap.SimpleEntry<String,ArrayList> CreateEntry(String
+    // key){
+    // return new AbstractMap.SimpleEntry<String, ArrayList>(key, new
+    // ArrayList<>());
+    // }
+
+    private ArrayList getColumnList(int columnIndex) {
+        return data.get(columnIndex).getValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void ChangeTableData(List<Pokemon> pokes) {
+        ClearTable();
+
+        MutableInt i = new MutableInt();
+
+        pokes.forEach(p -> {
+            pokeCol.add(i.getValue(), p);
+            getColumnList(0).add(i.getValue(),p.getMeta().getNumber());
+            getColumnList(1).add(i.getValue(),p.getNickname());
+            getColumnList(2).add(i.getValue(),PokeHandler.getLocalPokeName(p));            
+            getColumnList(3).add(i.getValue(),Utilities.percentageWithTwoCharacters(PokemonUtils.ivRating(p)));
+            getColumnList(4).add(i.getValue(),p.getLevel());
+            getColumnList(12).add(i.getValue(),p.getCp());
+            getColumnList(5).add(i.getValue(),p.getIndividualAttack());
+            getColumnList(6).add(i.getValue(),p.getIndividualDefense());
+            getColumnList(7).add(i.getValue(),p.getIndividualStamina());
+            getColumnList(8).add(i.getValue(),StringUtils.capitalize(p.getMeta().getType1().toString().toLowerCase()));
+            getColumnList(9).add(i.getValue(),StringUtils.capitalize(
+                    p.getMeta().getType2().toString().toLowerCase().replaceAll("none", "")));
+
+            Double dps1 = PokemonUtils.dpsForMove(p, true);
+            Double dps2 = PokemonUtils.dpsForMove(p, false);
+
+            getColumnList(10).add(i.getValue(),WordUtils.capitalize(
+                    p.getMove1().toString().toLowerCase().replaceAll("_fast", "").replaceAll("_", " "))
+                    + " (" + String.format("%.2f", dps1) + "dps)");
+            getColumnList(11)
+                    .add(i.getValue(),WordUtils.capitalize(p.getMove2().toString().toLowerCase().replaceAll("_", " ")) + " ("
+                            + String.format("%.2f", dps2) + "dps)");
+            getColumnList(13).add(i.getValue(),p.getMaxStamina());
+
+            int trainerLevel = 1;
+            try {
+                trainerLevel = go.getPlayerProfile().getStats().getLevel();
+            } catch (Exception e1) {
+                e1.printStackTrace();
+            }
+
+            // Max CP calculation for current Pokemon
+            PokemonMeta pokemonMeta = PokemonMetaRegistry.getMeta(p.getPokemonId());
+            int maxCpCurrent = 0, maxCp = 0;
+            if (pokemonMeta == null) {
+                System.out.println("Error: Cannot find meta data for " + p.getPokemonId().name());
+            } else {
+                int attack = p.getIndividualAttack() + pokemonMeta.getBaseAttack();
+                int defense = p.getIndividualDefense() + pokemonMeta.getBaseDefense();
+                int stamina = p.getIndividualStamina() + pokemonMeta.getBaseStamina();
+                maxCpCurrent = PokemonCpUtils.getMaxCpForTrainerLevel(attack, defense, stamina, trainerLevel);
+                maxCp = PokemonCpUtils.getMaxCp(attack, defense, stamina);
+                getColumnList(14).add(i.getValue(),maxCpCurrent);
+                getColumnList(15).add(i.getValue(),maxCp);
+            }
+
+            // Max CP calculation for highest evolution of current Pokemon
+            PokemonFamilyId familyId = p.getPokemonFamily();
+            PokemonId highestFamilyId = PokemonMetaRegistry.getHightestForFamily(familyId);
+
+            // Eeveelutions exception handling
+            if (familyId.getNumber() == PokemonFamilyId.FAMILY_EEVEE.getNumber()) {
+                if (p.getPokemonId().getNumber() == PokemonId.EEVEE.getNumber()) {
+                    PokemonMeta vap = PokemonMetaRegistry.getMeta(PokemonId.VAPOREON);
+                    PokemonMeta fla = PokemonMetaRegistry.getMeta(PokemonId.FLAREON);
+                    PokemonMeta jol = PokemonMetaRegistry.getMeta(PokemonId.JOLTEON);
+                    if (vap != null && fla != null && jol != null) {
+                        Comparator<PokemonMeta> cMeta = (m1, m2) -> {
+                            int comb1 = PokemonCpUtils.getMaxCp(m1.getBaseAttack(), m1.getBaseDefense(),
+                                    m1.getBaseStamina());
+                            int comb2 = PokemonCpUtils.getMaxCp(m2.getBaseAttack(), m2.getBaseDefense(),
+                                    m2.getBaseStamina());
+                            return comb1 - comb2;
+                        };
+                        highestFamilyId = PokemonId
+                                .forNumber(Collections.max(Arrays.asList(vap, fla, jol), cMeta).getNumber());
+                    }
+                } else {
+                    // This is one of the eeveelutions, so
+                    // PokemonMetaRegistry.getHightestForFamily() returns
+                    // Eevee.
+                    // We correct that here
+                    highestFamilyId = p.getPokemonId();
+                }
+            }
+
+            PokemonMeta highestFamilyMeta = PokemonMetaRegistry.getMeta(highestFamilyId);
+            if (highestFamilyId == p.getPokemonId()) {
+                getColumnList(16).add(i.getValue(),maxCpCurrent);
+                getColumnList(17).add(i.getValue(),maxCp);
+                getColumnList(29).add(i.getValue(),"-");
+            } else if (highestFamilyMeta == null) {
+                System.out.println("Error: Cannot find meta data for " + highestFamilyId.name());
+            } else {
+                int attack = highestFamilyMeta.getBaseAttack() + p.getIndividualAttack();
+                int defense = highestFamilyMeta.getBaseDefense() + p.getIndividualDefense();
+                int stamina = highestFamilyMeta.getBaseStamina() + p.getIndividualStamina();
+
+                getColumnList(16).add(i.getValue(),PokemonCpUtils.getMaxCpForTrainerLevel(attack, defense, stamina, trainerLevel));
+                getColumnList(17).add(i.getValue(),PokemonCpUtils.getMaxCp(attack, defense, stamina));
+                getColumnList(29).add(i.getValue(),String
+                        .valueOf(PokemonCpUtils.getCpForPokemonLevel(attack, defense, stamina, p.getLevel())));
+            }
+
+            int candies = 0;
+            try {
+                candies = p.getCandy();
+                getColumnList(18).add(i.getValue(),candies);
+                
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            if (p.getCandiesToEvolve() != 0) {
+                getColumnList(19).add(i.getValue(),String.valueOf(p.getCandiesToEvolve()));
+                getColumnList(30).add(i.getValue(),String.valueOf(GetEvolvable(candies, p.getCandiesToEvolve())));
+            } else {
+                getColumnList(19).add(i.getValue(),"-");
+                getColumnList(30).add(i.getValue(),"-");
+            }
+            getColumnList(20).add(i.getValue(),p.getStardustCostsForPowerup());
+            getColumnList(21).add(i.getValue(),WordUtils.capitalize(
+                    p.getPokeball().toString().toLowerCase().replaceAll("item_", "").replaceAll("_", " ")));
+            getColumnList(22).add(i.getValue(),DateHelper.toString(DateHelper.fromTimestamp(p.getCreationTimeMs())));
+            getColumnList(23).add(i.getValue(), (p.isFavorite()) ? "True" : "");
+            getColumnList(24).add(i.getValue(),PokemonUtils.duelAbility(p));
+            getColumnList(25).add(i.getValue(),PokemonUtils.gymOffense(p));
+            getColumnList(26).add(i.getValue(),PokemonUtils.gymDefense(p));
+            getColumnList(27).add(i.getValue(),PokemonUtils.moveRating(p, true));
+            getColumnList(28).add(i.getValue(),PokemonUtils.moveRating(p, false));
+            i.increment();
+        });
+        
+        fireTableDataChanged();
+    }
+
+    private void ClearTable() {
+        pokeCol.clear();
+        for (SimpleEntry<String, ArrayList> entry : data) {
+            entry.getValue().clear();
+        }
+    }
+
+    // Rounded down candies / toEvolve
+    private int GetEvolvable(int candies, int candiesToEvolve) {
+        return (int) ((double) candies / candiesToEvolve);
+    }
+
+    public Pokemon getPokemonByIndex(int i) {
+        try {
+            return pokeCol.get(pt.convertRowIndexToModel(i));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Override
+    public String getColumnName(int columnIndex) {
+        return data.get(columnIndex).getKey();
+    }
+
+    @Override
+    public int getColumnCount() {
+        // return 31;
+        return data.size();
+    }
+
+    @Override
+    public int getRowCount() {
+        return pokeCol.size();
+    }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        return data.get(columnIndex).getValue().get(rowIndex);
+    }
+}

--- a/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
+++ b/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
@@ -70,7 +70,7 @@ public class PokemonTableModel extends AbstractTableModel {
         data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Time Caught", new ArrayList<String>()));// 22
         data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Favorite", new ArrayList<String>()));// 23
         data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Duel Ability", new ArrayList<Long>()));// 24
-        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Offense", new ArrayList<Long>()));// 25
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Offense", new ArrayList<Double>()));// 25
         data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Defense", new ArrayList<Long>()));// 26
         data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 1 Rating", new ArrayList<String>()));// 27
         data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 2 Rating", new ArrayList<String>()));// 28

--- a/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
+++ b/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
@@ -1,0 +1,302 @@
+package me.corriekay.pokegoutil.utils.windows;
+
+import java.util.AbstractMap;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import javax.swing.table.AbstractTableModel;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.commons.lang3.text.WordUtils;
+
+import com.pokegoapi.api.PokemonGo;
+import com.pokegoapi.api.pokemon.Pokemon;
+import com.pokegoapi.api.pokemon.PokemonMeta;
+import com.pokegoapi.api.pokemon.PokemonMetaRegistry;
+
+import POGOProtos.Enums.PokemonFamilyIdOuterClass.PokemonFamilyId;
+import POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
+import me.corriekay.pokegoutil.utils.Utilities;
+import me.corriekay.pokegoutil.utils.helpers.DateHelper;
+import me.corriekay.pokegoutil.utils.pokemon.PokeHandler;
+import me.corriekay.pokegoutil.utils.pokemon.PokemonCpUtils;
+import me.corriekay.pokegoutil.utils.pokemon.PokemonUtils;
+
+@SuppressWarnings({"serial","rawtypes"})
+
+public class PokemonTableModel extends AbstractTableModel {
+
+    PokemonTable pt;
+
+    private ArrayList<Pokemon> pokeCol = new ArrayList<>();
+    /*
+     * private ArrayList<Integer> numIdCol = new ArrayList<>();// 0 private
+     * ArrayList<String> nickCol = new ArrayList<>(), // 1 speciesCol = new
+     * ArrayList<>(), // 2 ivCol = new ArrayList<>();// 3 private
+     * ArrayList<Double> levelCol = new ArrayList<>();// 4 private
+     * ArrayList<Integer> atkCol = new ArrayList<>(), // 5 defCol = new
+     * ArrayList<>(), // 6 stamCol = new ArrayList<>();// 7 private
+     * ArrayList<String> type1Col = new ArrayList<>(), // 8 type2Col = new
+     * ArrayList<>(), // 9 move1Col = new ArrayList<>(), // 10 move2Col = new
+     * ArrayList<>();// 11 private ArrayList<Integer> cpCol = new ArrayList<>(),
+     * // 12 hpCol = new ArrayList<>(), // 13 maxCpCurrentCol = new
+     * ArrayList<>(), // 14 maxCpCol = new ArrayList<>(), // 15
+     * maxEvolvedCpCurrentCol = new ArrayList<>(), // 16 maxEvolvedCpCol = new
+     * ArrayList<>(), // 17 candiesCol = new ArrayList<>();// 18 private
+     * ArrayList<String> candies2EvlvCol = new ArrayList<>();// 19 private
+     * ArrayList<Integer> dustToLevelCol = new ArrayList<>();// 20 private
+     * ArrayList<String> pokeballCol = new ArrayList<>(), // 21 caughtCol = new
+     * ArrayList<>(), // 22 favCol = new ArrayList<>();// 23 private
+     * ArrayList<Long> duelAbilityCol = new ArrayList<>();// 24 private
+     * ArrayList<Long> gymOffenseCol = new ArrayList<>();// 25 private
+     * ArrayList<Long> gymDefenseCol = new ArrayList<>();// 26 private
+     * ArrayList<String> move1RatingCol = new ArrayList<>(), // 27
+     * move2RatingCol = new ArrayList<>();// 28 private ArrayList<String>
+     * cpEvolvedCol = new ArrayList<>(), // 29 evolvableCol = new
+     * ArrayList<>();// 30
+     */
+    private PokemonGo go;
+
+    private ArrayList<AbstractMap.SimpleEntry<String, ArrayList>> data;
+
+    @Deprecated
+    PokemonTableModel(PokemonGo go, List<Pokemon> pokes, PokemonTable pt) {
+        this.pt = pt;
+        this.go = go;
+
+        data = new ArrayList<AbstractMap.SimpleEntry<String,ArrayList>>();
+        
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Id", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Nickname", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Species", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("IV %", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Lvl", new ArrayList<Double>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Atk", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Def", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Stam", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Type 1", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Type 2", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 1", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 2", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("CP", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("HP", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max CP (Cur)", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max CP (40)", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Max Evolved CP (Cur)",
+                new ArrayList<Integer>()));
+        data.add(
+                new AbstractMap.SimpleEntry<String, ArrayList>("Max Evolved CP (40)", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Candies", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("To Evolve", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Stardust", new ArrayList<Integer>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Caught With", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Time Caught", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Favorite", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Duel Ability", new ArrayList<Long>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Offense", new ArrayList<Long>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Defense", new ArrayList<Long>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 1 Rating", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Move 2 Rating", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("CP Evolved", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Evolvable", new ArrayList<String>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Duel Ability IV", new ArrayList<Long>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Offense IV", new ArrayList<Double>()));
+        data.add(new AbstractMap.SimpleEntry<String, ArrayList>("Gym Defense IV", new ArrayList<Long>()));
+      
+        ChangeTableData(pokes);
+    }
+
+    // private AbstractMap.SimpleEntry<String,ArrayList> CreateEntry(String
+    // key){
+    // return new AbstractMap.SimpleEntry<String, ArrayList>(key, new
+    // ArrayList<>());
+    // }
+
+    private ArrayList getColumnList(int columnIndex) {
+        return data.get(columnIndex).getValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void ChangeTableData(List<Pokemon> pokes) {
+        ClearTable();
+
+        MutableInt i = new MutableInt();
+
+        pokes.forEach(p -> {
+            pokeCol.add(i.getValue(), p);
+            getColumnList(0).add(i.getValue(),p.getMeta().getNumber());
+            getColumnList(1).add(i.getValue(),p.getNickname());
+            getColumnList(2).add(i.getValue(),PokeHandler.getLocalPokeName(p));            
+            getColumnList(3).add(i.getValue(),Utilities.percentageWithTwoCharacters(PokemonUtils.ivRating(p)));
+            getColumnList(4).add(i.getValue(),p.getLevel());
+            getColumnList(12).add(i.getValue(),p.getCp());
+            getColumnList(5).add(i.getValue(),p.getIndividualAttack());
+            getColumnList(6).add(i.getValue(),p.getIndividualDefense());
+            getColumnList(7).add(i.getValue(),p.getIndividualStamina());
+            getColumnList(8).add(i.getValue(),StringUtils.capitalize(p.getMeta().getType1().toString().toLowerCase()));
+            getColumnList(9).add(i.getValue(),StringUtils.capitalize(
+                    p.getMeta().getType2().toString().toLowerCase().replaceAll("none", "")));
+
+            Double dps1 = PokemonUtils.dpsForMove(p, true);
+            Double dps2 = PokemonUtils.dpsForMove(p, false);
+
+            getColumnList(10).add(i.getValue(),WordUtils.capitalize(
+                    p.getMove1().toString().toLowerCase().replaceAll("_fast", "").replaceAll("_", " "))
+                    + " (" + String.format("%.2f", dps1) + "dps)");
+            getColumnList(11)
+                    .add(i.getValue(),WordUtils.capitalize(p.getMove2().toString().toLowerCase().replaceAll("_", " ")) + " ("
+                            + String.format("%.2f", dps2) + "dps)");
+            getColumnList(13).add(i.getValue(),p.getMaxStamina());
+
+            int trainerLevel = 1;
+            try {
+                trainerLevel = go.getPlayerProfile().getStats().getLevel();
+            } catch (Exception e1) {
+                e1.printStackTrace();
+            }
+
+            // Max CP calculation for current Pokemon
+            PokemonMeta pokemonMeta = PokemonMetaRegistry.getMeta(p.getPokemonId());
+            int maxCpCurrent = 0, maxCp = 0;
+            if (pokemonMeta == null) {
+                System.out.println("Error: Cannot find meta data for " + p.getPokemonId().name());
+            } else {
+                int attack = p.getIndividualAttack() + pokemonMeta.getBaseAttack();
+                int defense = p.getIndividualDefense() + pokemonMeta.getBaseDefense();
+                int stamina = p.getIndividualStamina() + pokemonMeta.getBaseStamina();
+                maxCpCurrent = PokemonCpUtils.getMaxCpForTrainerLevel(attack, defense, stamina, trainerLevel);
+                maxCp = PokemonCpUtils.getMaxCp(attack, defense, stamina);
+                getColumnList(14).add(i.getValue(),maxCpCurrent);
+                getColumnList(15).add(i.getValue(),maxCp);
+            }
+
+            // Max CP calculation for highest evolution of current Pokemon
+            PokemonFamilyId familyId = p.getPokemonFamily();
+            PokemonId highestFamilyId = PokemonMetaRegistry.getHightestForFamily(familyId);
+
+            // Eeveelutions exception handling
+            if (familyId.getNumber() == PokemonFamilyId.FAMILY_EEVEE.getNumber()) {
+                if (p.getPokemonId().getNumber() == PokemonId.EEVEE.getNumber()) {
+                    PokemonMeta vap = PokemonMetaRegistry.getMeta(PokemonId.VAPOREON);
+                    PokemonMeta fla = PokemonMetaRegistry.getMeta(PokemonId.FLAREON);
+                    PokemonMeta jol = PokemonMetaRegistry.getMeta(PokemonId.JOLTEON);
+                    if (vap != null && fla != null && jol != null) {
+                        Comparator<PokemonMeta> cMeta = (m1, m2) -> {
+                            int comb1 = PokemonCpUtils.getMaxCp(m1.getBaseAttack(), m1.getBaseDefense(),
+                                    m1.getBaseStamina());
+                            int comb2 = PokemonCpUtils.getMaxCp(m2.getBaseAttack(), m2.getBaseDefense(),
+                                    m2.getBaseStamina());
+                            return comb1 - comb2;
+                        };
+                        highestFamilyId = PokemonId
+                                .forNumber(Collections.max(Arrays.asList(vap, fla, jol), cMeta).getNumber());
+                    }
+                } else {
+                    // This is one of the eeveelutions, so
+                    // PokemonMetaRegistry.getHightestForFamily() returns
+                    // Eevee.
+                    // We correct that here
+                    highestFamilyId = p.getPokemonId();
+                }
+            }
+
+            PokemonMeta highestFamilyMeta = PokemonMetaRegistry.getMeta(highestFamilyId);
+            if (highestFamilyId == p.getPokemonId()) {
+                getColumnList(16).add(i.getValue(),maxCpCurrent);
+                getColumnList(17).add(i.getValue(),maxCp);
+                getColumnList(29).add(i.getValue(),"-");
+            } else if (highestFamilyMeta == null) {
+                System.out.println("Error: Cannot find meta data for " + highestFamilyId.name());
+            } else {
+                int attack = highestFamilyMeta.getBaseAttack() + p.getIndividualAttack();
+                int defense = highestFamilyMeta.getBaseDefense() + p.getIndividualDefense();
+                int stamina = highestFamilyMeta.getBaseStamina() + p.getIndividualStamina();
+
+                getColumnList(16).add(i.getValue(),PokemonCpUtils.getMaxCpForTrainerLevel(attack, defense, stamina, trainerLevel));
+                getColumnList(17).add(i.getValue(),PokemonCpUtils.getMaxCp(attack, defense, stamina));
+                getColumnList(29).add(i.getValue(),String
+                        .valueOf(PokemonCpUtils.getCpForPokemonLevel(attack, defense, stamina, p.getLevel())));
+            }
+
+            int candies = 0;
+            try {
+                candies = p.getCandy();
+                getColumnList(18).add(i.getValue(),candies);
+                
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            if (p.getCandiesToEvolve() != 0) {
+                getColumnList(19).add(i.getValue(),String.valueOf(p.getCandiesToEvolve()));
+                getColumnList(30).add(i.getValue(),String.valueOf(GetEvolvable(candies, p.getCandiesToEvolve())));
+            } else {
+                getColumnList(19).add(i.getValue(),"-");
+                getColumnList(30).add(i.getValue(),"-");
+            }
+            getColumnList(20).add(i.getValue(),p.getStardustCostsForPowerup());
+            getColumnList(21).add(i.getValue(),WordUtils.capitalize(
+                    p.getPokeball().toString().toLowerCase().replaceAll("item_", "").replaceAll("_", " ")));
+            getColumnList(22).add(i.getValue(),DateHelper.toString(DateHelper.fromTimestamp(p.getCreationTimeMs())));
+            getColumnList(23).add(i.getValue(), (p.isFavorite()) ? "True" : "");
+            getColumnList(24).add(i.getValue(),PokemonUtils.duelAbility(p, false));
+            getColumnList(25).add(i.getValue(),PokemonUtils.gymOffense(p, false));
+            getColumnList(26).add(i.getValue(),PokemonUtils.gymDefense(p, false));
+            getColumnList(27).add(i.getValue(),PokemonUtils.moveRating(p, true));
+            getColumnList(28).add(i.getValue(),PokemonUtils.moveRating(p, false));
+            getColumnList(31).add(i.getValue(),PokemonUtils.duelAbility(p, true));
+            getColumnList(32).add(i.getValue(),PokemonUtils.gymOffense(p, true));
+            getColumnList(33).add(i.getValue(),PokemonUtils.gymDefense(p, false));
+            
+            i.increment();
+        });
+        
+        fireTableDataChanged();
+    }
+
+    private void ClearTable() {
+        pokeCol.clear();
+        for (SimpleEntry<String, ArrayList> entry : data) {
+            entry.getValue().clear();
+        }
+    }
+
+    // Rounded down candies / toEvolve
+    private int GetEvolvable(int candies, int candiesToEvolve) {
+        return (int) ((double) candies / candiesToEvolve);
+    }
+
+    public Pokemon getPokemonByIndex(int i) {
+        try {
+            return pokeCol.get(pt.convertRowIndexToModel(i));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Override
+    public String getColumnName(int columnIndex) {
+        return data.get(columnIndex).getKey();
+    }
+
+    @Override
+    public int getColumnCount() {
+        // return 31;
+        return data.size();
+    }
+
+    @Override
+    public int getRowCount() {
+        return pokeCol.size();
+    }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        return data.get(columnIndex).getValue().get(rowIndex);
+    }
+}

--- a/src/me/corriekay/pokegoutil/windows/MenuBar.java
+++ b/src/me/corriekay/pokegoutil/windows/MenuBar.java
@@ -58,25 +58,31 @@ public class MenuBar extends JMenuBar {
 
         JCheckBoxMenuItem doNotShowBulkPopup = new JCheckBoxMenuItem("Show Bulk Completion Window");
         doNotShowBulkPopup.setSelected(config.getBool(ConfigKey.SHOW_BULK_POPUP));
-        doNotShowBulkPopup.addItemListener(e -> config.setBool(ConfigKey.SHOW_BULK_POPUP, doNotShowBulkPopup.isSelected()));
+        doNotShowBulkPopup.addItemListener(
+                e -> {
+                    config.setBool(ConfigKey.SHOW_BULK_POPUP, doNotShowBulkPopup.isSelected());
+                });
         settings.add(doNotShowBulkPopup);
 
         JCheckBoxMenuItem includeFamily = new JCheckBoxMenuItem("Include Family On Searchbar");
         includeFamily.setSelected(config.getBool(ConfigKey.INCLUDE_FAMILY));
-        includeFamily.addItemListener(e -> {
-            config.setBool(ConfigKey.INCLUDE_FAMILY, includeFamily.isSelected());
-            if (!pokemonTab.getSelectedPokemon().isEmpty()) {
-                SwingUtilities.invokeLater(pokemonTab::refreshList);
-            }
-        });
+        includeFamily.addItemListener(
+                e -> {
+                    config.setBool(ConfigKey.INCLUDE_FAMILY, includeFamily.isSelected());
+                    if (!pokemonTab.getSelectedPokemon().isEmpty()) {
+                        SwingUtilities.invokeLater(pokemonTab::refreshList);
+                    }
+                });
         settings.add(includeFamily);
 
-        JCheckBoxMenuItem alternativeIVCalculation = new JCheckBoxMenuItem("Use Alternative IV Calculation (weighted stats)");
+        JCheckBoxMenuItem alternativeIVCalculation = new JCheckBoxMenuItem(
+                "Use Alternative IV Calculation (weighted stats)");
         alternativeIVCalculation.setSelected(config.getBool(ConfigKey.ALTERNATIVE_IV_CALCULATION));
-        alternativeIVCalculation.addItemListener(e -> {
-            config.setBool(ConfigKey.ALTERNATIVE_IV_CALCULATION, alternativeIVCalculation.isSelected());
-            SwingUtilities.invokeLater(pokemonTab::refreshList);
-        });
+        alternativeIVCalculation.addItemListener(
+                e -> {
+                    config.setBool(ConfigKey.ALTERNATIVE_IV_CALCULATION, alternativeIVCalculation.isSelected());
+                    SwingUtilities.invokeLater(pokemonTab::refreshList);
+                });
         settings.add(alternativeIVCalculation);
 
         add(settings);
@@ -121,11 +127,12 @@ public class MenuBar extends JMenuBar {
         go.getInventories().updateInventories(true);
         PlayerProfile pp = go.getPlayerProfile();
         Stats stats = pp.getStats();
-        Object[] tstats = {"Trainer Name: " + pp.getPlayerData().getUsername(),
+        Object[] tstats = {
+                "Trainer Name: " + pp.getPlayerData().getUsername(),
                 "Team: " + PokemonUtils.convertTeamColorToName(pp.getPlayerData().getTeamValue()),
-                "Level: " + stats.getLevel(), "XP: " + stats.getExperience() + " ("
-                + (stats.getNextLevelXp() - stats.getExperience()) + " to next level)",
-                "Stardust: " + pp.getCurrency(Currency.STARDUST)};
+                "Level: " + stats.getLevel(), "XP: " + stats.getExperience()
+                        + " (" + (stats.getNextLevelXp() - stats.getExperience()) + " to next level)",
+                "Stardust: " + pp.getCurrency(Currency.STARDUST) };
         JOptionPane.showMessageDialog(null, tstats, "Trainer Stats", JOptionPane.PLAIN_MESSAGE);
     }
 }

--- a/src/me/corriekay/pokegoutil/windows/MenuBar.java
+++ b/src/me/corriekay/pokegoutil/windows/MenuBar.java
@@ -128,11 +128,13 @@ public class MenuBar extends JMenuBar {
         PlayerProfile pp = go.getPlayerProfile();
         Stats stats = pp.getStats();
         Object[] tstats = {
-                "Trainer Name: " + pp.getPlayerData().getUsername(),
-                "Team: " + PokemonUtils.convertTeamColorToName(pp.getPlayerData().getTeamValue()),
-                "Level: " + stats.getLevel(), "XP: " + stats.getExperience()
-                        + " (" + (stats.getNextLevelXp() - stats.getExperience()) + " to next level)",
-                "Stardust: " + pp.getCurrency(Currency.STARDUST) };
+                String.format("Trainer Name: %s", pp.getPlayerData().getUsername()),
+                String.format("Team: %s", PokemonUtils.convertTeamColorToName(pp.getPlayerData().getTeamValue())),
+                String.format("Level: %d", stats.getLevel()),
+                String.format("XP: %d (%d to next level)",
+                        stats.getExperience(),
+                        (stats.getNextLevelXp() - stats.getExperience())),
+                String.format("Stardust: %d", pp.getCurrency(Currency.STARDUST)) };
         JOptionPane.showMessageDialog(null, tstats, "Trainer Stats", JOptionPane.PLAIN_MESSAGE);
     }
 }

--- a/src/me/corriekay/pokegoutil/windows/PokemonGoMainWindow.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonGoMainWindow.java
@@ -33,21 +33,27 @@ public class PokemonGoMainWindow extends JFrame {
 
         console.clearAllLines();
         try {
+            System.out.println(String.format("Successfully logged in. Welcome, %s.", pp.getPlayerData().getUsername()));
+            System.out.println(String.format("Stats: Lvl %d %s player.",
+                    pp.getStats().getLevel(),
+                    PokemonUtils.convertTeamColorToName(pp.getPlayerData().getTeamValue())));
 
-            System.out.println("Successfully logged in. Welcome, " + pp.getPlayerData().getUsername() + ".");
-            System.out.println("Stats: Lvl " + pp.getStats().getLevel() + " "
-                    + PokemonUtils.convertTeamColorToName(pp.getPlayerData().getTeamValue()) + " player.");
-            System.out.println("Pokédex - Types Caught: " + pp.getStats().getUniquePokedexEntries()
-                    + ", Total Pokémon Caught: " + pp.getStats().getPokemonsCaptured() + ", Total Current Pokémon: "
-                    + go.getInventories().getPokebank().getPokemons().size() + " (+" + go.getInventories().getHatchery().getEggs().size() + " Eggs)");
+            String msg = String.format("Pokédex - Types Caught: %d, ", pp.getStats().getUniquePokedexEntries());
+            msg += String.format("Total Pokémon Caught: %d, ", pp.getStats().getPokemonsCaptured());
+            msg += String.format("Total Current Pokémon: %d (+%d Eggs)",
+                    go.getInventories().getPokebank().getPokemons().size(),
+                    go.getInventories().getHatchery().getEggs().size());
+            System.out.println(msg);
+
         } catch (RemoteServerException | LoginFailedException e) {
             // System.out.println("Unable to login!");
             // e.printStackTrace();
         }
-        setLayout(new BorderLayout());
         refreshTitle();
+        setLayout(new BorderLayout());
         setIconImage(FileHelper.loadImage("icon/PokeBall-icon.png"));
         setBounds(0, 0, config.getInt(ConfigKey.WINDOW_WIDTH), config.getInt(ConfigKey.WINDOW_HEIGHT));
+
         // add EventHandler to save new window size and position to
         // config for the app to remember over restarts
         this.addComponentListener(new ComponentAdapter() {
@@ -65,11 +71,13 @@ public class PokemonGoMainWindow extends JFrame {
                 config.setInt(ConfigKey.WINDOW_POS_Y, w.getY());
             }
         });
+
         Point pt = UIHelper.getLocationMidScreen(this);
         int posx = config.getInt(ConfigKey.WINDOW_POS_X, pt.x);
         int posy = config.getInt(ConfigKey.WINDOW_POS_Y, pt.y);
         setLocation(posx, posy);
         setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
         PokemonTab pokemonTab = new PokemonTab(go);
         setJMenuBar(new MenuBar(go, pokemonTab));
         tab.add("Pokémon", pokemonTab);
@@ -90,7 +98,8 @@ public class PokemonGoMainWindow extends JFrame {
     public void refreshTitle() {
         try {
             NumberFormat f = NumberFormat.getInstance();
-            setTitle(String.format("%s - Stardust: %s - Blossom's Pokémon Go Manager", pp.getPlayerData().getUsername(),
+            setTitle(String.format("%s - Stardust: %s - Blossom's Pokémon Go Manager",
+                    pp.getPlayerData().getUsername(),
                     f.format(pp.getCurrency(PlayerProfile.Currency.STARDUST))));
         } catch (InvalidCurrencyException | LoginFailedException | RemoteServerException e) {
             setTitle("Blossom's Pokémon Go Manager");

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -160,7 +160,7 @@ public class PokemonTab extends JPanel {
         gbc.fill = GridBagConstraints.HORIZONTAL;
         topPanel.add(searchBar, gbc);
 
-        // pokemon name language drop down
+        // Pokemon name language drop down
         String[] locales = { "en", "de", "fr", "ru", "zh_CN", "zh_HK", "ja" };
         JComboBox<String> pokelang = new JComboBox<>(locales);
         String locale = config.getString(ConfigKey.LANGUAGE);

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -270,24 +270,18 @@ public class PokemonTab extends JPanel {
             if (renameResult.getNumber() == NicknamePokemonResponse.Result.SUCCESS_VALUE) {
                 success.increment();
                 if (pokeNick.isTooLong()) {
-                    System.out.println("WARNING: Nickname \""
-                            + pokeNick.fullNickname
-                            + "\" is too long. Get's cut to: "
-                            + pokeNick.toString());
+                    System.out.println("WARNING: Nickname \"" + pokeNick.fullNickname
+                            + "\" is too long. Get's cut to: " + pokeNick.toString());
                 }
-                System.out.println("Renaming "
-                        + PokeHandler.getLocalPokeName(pokemon)
-                        + " from \""
-                        + pokemon.getNickname() + "\" to \""
-                        + PokeHandler.generatePokemonNickname(renamePattern, pokemon)
+                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon)
+                        + " from \"" + pokemon.getNickname()
+                        + "\" to \"" + PokeHandler.generatePokemonNickname(renamePattern, pokemon)
                         + "\", Result: Success!");
             } else {
                 err.increment();
-                System.out.println("Renaming "
-                        + PokeHandler.getLocalPokeName(pokemon)
-                        + " failed! Code: "
-                        + renameResult.toString() + "; Nick: "
-                        + PokeHandler.generatePokemonNickname(renamePattern, pokemon));
+                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon)
+                        + " failed! Code: " + renameResult.toString()
+                        + "; Nick: " + PokeHandler.generatePokemonNickname(renamePattern, pokemon));
             }
 
             // If not last element and API was queried, sleep until the next one
@@ -322,17 +316,15 @@ public class PokemonTab extends JPanel {
                 System.out.println("Doing Transfer " + total.getValue() + " of " + selection.size());
                 total.increment();
                 if (poke.isFavorite()) {
-                    System.out.println(PokeHandler.getLocalPokeName(poke)
-                            + " with " + poke.getCp()
-                            + " CP is favorite, skipping.");
+                    System.out.println(PokeHandler.getLocalPokeName(poke) + " with "
+                            + poke.getCp() + " CP is favorite, skipping.");
                     skipped.increment();
                     return;
                 }
                 if (!poke.getDeployedFortId().isEmpty()) {
                     System.out.println(
-                            PokeHandler.getLocalPokeName(poke)
-                                    + " with " + poke.getCp()
-                                    + " CP is in gym, skipping.");
+                            PokeHandler.getLocalPokeName(poke) + " with "
+                                    + poke.getCp() + " CP is in gym, skipping.");
                     skipped.increment();
                     return;
                 }
@@ -345,11 +337,9 @@ public class PokemonTab extends JPanel {
                     if (transferResult == ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result.SUCCESS) {
                         int newCandies = poke.getCandy();
                         System.out.println("Transferring " + PokeHandler.getLocalPokeName(poke) + ", Result: Success!");
-                        System.out.println(
-                                "Stat changes: (Candies : "
-                                        + newCandies
-                                        + "[+" + (newCandies - candies)
-                                        + "])");
+                        System.out.println("Stat changes: "
+                                + "(Candies : " + newCandies
+                                + "[+" + (newCandies - candies) + "])");
                         success.increment();
                     } else {
                         System.out.println("Error transferring "
@@ -396,9 +386,8 @@ public class PokemonTab extends JPanel {
                             + " of " + selection.size());
                     total.increment();
                     if (!poke.getDeployedFortId().isEmpty()) {
-                        System.out.println(PokeHandler.getLocalPokeName(poke)
-                                + " with " + poke.getCp()
-                                + " CP is in gym, skipping.");
+                        System.out.println(PokeHandler.getLocalPokeName(poke) + " with "
+                                + poke.getCp() + " CP is in gym, skipping.");
                         skipped.increment();
                         return;
                     }
@@ -415,8 +404,7 @@ public class PokemonTab extends JPanel {
                             err.increment();
                             System.out.println("Error. Not enough candy to evolve "
                                     + PokeHandler.getLocalPokeName(poke) + ". "
-                                    + candies + " available, "
-                                    + candiesToEvolve + " needed.");
+                                    + candies + " available, " + candiesToEvolve + " needed.");
                             return;
                         }
 
@@ -493,9 +481,8 @@ public class PokemonTab extends JPanel {
                         System.out.println("Doing Power Up " + total.getValue() + " of " + selection.size());
                         total.increment();
                         if (!poke.getDeployedFortId().isEmpty()) {
-                            System.out.println(PokeHandler.getLocalPokeName(poke)
-                                    + " with " + poke.getCp()
-                                    + " CP is in gym, skipping.");
+                            System.out.println(PokeHandler.getLocalPokeName(poke) + " with "
+                                    + poke.getCp() + " CP is in gym, skipping.");
                             skipped.increment();
                             return;
                         }
@@ -581,8 +568,9 @@ public class PokemonTab extends JPanel {
                         go.getPlayerProfile().updateProfile();
 
                         if (favoriteResult == SetFavoritePokemonResponseOuterClass.SetFavoritePokemonResponse.Result.SUCCESS) {
-                            System.out.println("Favorite for " + PokeHandler.getLocalPokeName(poke) + " set to "
-                                    + !poke.isFavorite() + ", Result: Success!");
+                            System.out.println("Favorite for " + PokeHandler.getLocalPokeName(poke)
+                                    + " set to " + !poke.isFavorite()
+                                    + ", Result: Success!");
                             success.increment();
                         } else {
                             err.increment();
@@ -598,8 +586,9 @@ public class PokemonTab extends JPanel {
                         }
                     } catch (Exception e) {
                         err.increment();
-                        System.out.println("Error toggling favorite for " + PokeHandler.getLocalPokeName(poke) + "! "
-                                + Utilities.getRealExceptionMessage(e));
+                        System.out.println("Error toggling favorite for "
+                                + PokeHandler.getLocalPokeName(poke)
+                                + "! " + Utilities.getRealExceptionMessage(e));
                     }
                 });
                 try {
@@ -642,7 +631,8 @@ public class PokemonTab extends JPanel {
         switch (operation) {
         case "Rename":
             message = "You want to rename " + pokes.size()
-                    + " Pokémon.\nYou can rename with normal text and patterns, or both combined. Patterns are going to be replaced with the Pokémons values.\nExisting patterns:\n";
+                    + " Pokémon.\nYou can rename with normal text and patterns, or both combined. "
+                    + "Patterns are going to be replaced with the Pokémons values.\nExisting patterns:\n";
             for (PokeHandler.ReplacePattern pattern : PokeHandler.ReplacePattern.values()) {
                 message += "%" + pattern.name().toLowerCase() + "% -> " + pattern.toString() + "\n";
             }

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -701,11 +701,14 @@ public class PokemonTab extends JPanel {
         String message = "";
         switch (operation) {
         case "Rename":
-            message = "You want to rename " + pokes.size()
-                    + " Pokémon.\nYou can rename with normal text and patterns, or both combined. "
-                    + "Patterns are going to be replaced with the Pokémons values.\nExisting patterns:\n";
+            message = String.format("You want to rename %d Pokémon.", pokes.size())
+                    + "\nYou can rename with normal text and patterns, or both combined. "
+                    + "Patterns are going to be replaced with the Pokémons values."
+                    + "\nExisting patterns:\n";
             for (PokeHandler.ReplacePattern pattern : PokeHandler.ReplacePattern.values()) {
-                message += "%" + pattern.name().toLowerCase() + "% -> " + pattern.toString() + "\n";
+                message += String.format("%% %s%% -> %s\n",
+                        pattern.name().toLowerCase(),
+                        pattern.toString());
             }
             message += "\n";
         }
@@ -718,7 +721,11 @@ public class PokemonTab extends JPanel {
         JPanel panel = _buildPanelForOperation(operation, pokes);
 
         int response = JOptionPane.showConfirmDialog(null, panel,
-                "Please confirm " + operation + " of " + pokes.size() + " Pokémon", JOptionPane.OK_CANCEL_OPTION,
+                String.format(
+                        "Please confirm %s of %d Pokémon",
+                        operation,
+                        pokes.size()),
+                JOptionPane.OK_CANCEL_OPTION,
                 JOptionPane.PLAIN_MESSAGE);
         return response == JOptionPane.OK_OPTION;
     }
@@ -743,8 +750,11 @@ public class PokemonTab extends JPanel {
         panel.setPreferredSize(new Dimension(500, height));
 
         pokes.forEach(p -> {
-            String str = PokeHandler.getLocalPokeName(p) + " - CP: " + p.getCp() + ", IV: "
-                    + Utilities.percentageWithTwoCharacters(PokemonUtils.ivRating(p)) + "%";
+            String str = String.format("%s - CP: %d, IV: %s%%",
+                    PokeHandler.getLocalPokeName(p),
+                    p.getCp(),
+                    Utilities.percentageWithTwoCharacters(PokemonUtils.ivRating(p)));
+
             switch (operation) {
             case "Evolve":
                 str += " Cost: " + p.getCandiesToEvolve();

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -459,9 +459,9 @@ public class PokemonTab extends JPanel {
                     } else {
                         System.out.println(String.format(
                                 "Stat changes: "
-                                        + "(Candies: %d[%d-%d],"
-                                        + " CP: %d[+%d],"
-                                        + " HP: %d[+%d])",
+                                        + "(Candies: %d[%d-%d], "
+                                        + "CP: %d[+%d], "
+                                        + "HP: %d[+%d])",
                                 newCandies, candies, candiesToEvolve,
                                 newCp, (newCp - cp),
                                 newHp, (newHp - hp)));
@@ -514,13 +514,18 @@ public class PokemonTab extends JPanel {
                 skipped = new MutableInt(),
                 success = new MutableInt(),
                 total = new MutableInt(1);
+
         selection.forEach(poke -> {
             try {
-                System.out.println("Doing Power Up " + total.getValue() + " of " + selection.size());
+                System.out.println(String.format("Doing Power Up %d of %d",
+                        total.getValue(),
+                        selection.size()));
                 total.increment();
                 if (!poke.getDeployedFortId().isEmpty()) {
-                    System.out.println(PokeHandler.getLocalPokeName(poke) + " with "
-                            + poke.getCp() + " CP is in gym, skipping.");
+                    System.out.println(String.format(
+                            "%s with %d CP is in gym, skipping.",
+                            PokeHandler.getLocalPokeName(poke),
+                            +poke.getCp()));
                     skipped.increment();
                     return;
                 }
@@ -536,10 +541,13 @@ public class PokemonTab extends JPanel {
                 // otherwise we don't need to call server
                 if (candies < candiesToPowerUp || stardust < stardustToPowerUp) {
                     err.increment();
-                    System.out.println("Error. Not enough candy/stardust to power up "
-                            + PokeHandler.getLocalPokeName(poke)
-                            + ". Stardust: " + stardust + "/" + stardustToPowerUp
-                            + ", Candy: " + candies + "/" + candiesToPowerUp);
+                    System.out.println(String.format(
+                            "Error. Not enough candy/stardust to power up %s. "
+                                    + "Stardust: %d/%d, "
+                                    + "Candy: %d/%d",
+                            PokeHandler.getLocalPokeName(poke),
+                            stardust, stardustToPowerUp,
+                            candies, candiesToPowerUp));
                     return;
                 }
 
@@ -549,19 +557,29 @@ public class PokemonTab extends JPanel {
                     int newCandies = poke.getCandy();
                     int newCp = poke.getCp();
                     int newHp = poke.getMaxStamina();
-                    System.out.println(
-                            "Powering Up " + PokeHandler.getLocalPokeName(poke) + ", Result: Success!");
-                    System.out.println("Stat changes: " +
-                            "(Candies : " + newCandies + "[" + candies + "-" + candiesToPowerUp + "], "
-                            + "CP: " + newCp + "[+" + (newCp - cp) + "], "
-                            + "HP: " + newHp + "[+" + (newHp - hp) + "]) "
-                            + "Stardust used " + stardustToPowerUp
-                            + "[remaining: " + go.getPlayerProfile().getCurrency(Currency.STARDUST) + "]");
+                    System.out.println(String.format(
+                            "Powering Up %s, Result: Success!",
+                            PokeHandler.getLocalPokeName(poke)));
+
+                    System.out.println(String.format(
+                            "Stat changes: "
+                                    + "(Candies : %d[%d-%d], "
+                                    + "CP: %d[+%d], "
+                                    + "HP: %d[+%d], "
+                                    + "Stardust used %d[remainding: %d])",
+                            newCandies, candies, candiesToPowerUp,
+                            newCp, (newCp - cp),
+                            newHp, (newHp - hp),
+                            stardustToPowerUp,
+                            go.getPlayerProfile().getCurrency(Currency.STARDUST)));
+
                     success.increment();
                 } else {
                     err.increment();
-                    System.out.println("Error powering up " + PokeHandler.getLocalPokeName(poke) + ", result: "
-                            + upgradeResult.toString());
+                    System.out.println(String.format(
+                            "Error powering up %s, result: %s",
+                            PokeHandler.getLocalPokeName(poke),
+                            upgradeResult.toString()));
                 }
 
                 // If not last element, sleep until the next one
@@ -572,8 +590,10 @@ public class PokemonTab extends JPanel {
                 }
             } catch (Exception e) {
                 err.increment();
-                System.out.println("Error powering up " + PokeHandler.getLocalPokeName(poke) + "! "
-                        + Utilities.getRealExceptionMessage(e));
+                System.out.println(String.format(
+                        "Error powering up %s! %s",
+                        PokeHandler.getLocalPokeName(poke),
+                        Utilities.getRealExceptionMessage(e)));
             }
         });
         try {

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -246,7 +246,7 @@ public class PokemonTab extends JPanel {
         PokeHandler handler = new PokeHandler(selection);
 
         BiConsumer<NicknamePokemonResponse.Result, Pokemon> perPokeCallback = (renameResult, pokemon) -> {
-            System.out.println("Doing Rename " + total.getValue() + " of " + selection.size());
+            System.out.println(String.format("Doing Rename %d of %d", total.getValue(), selection.size()));
             total.increment();
 
             PokeNick pokeNick = PokeHandler.generatePokemonNickname(renamePattern, pokemon);
@@ -255,10 +255,9 @@ public class PokemonTab extends JPanel {
             boolean isSkipped = (pokeNick.equals(pokemon.getNickname())
                     && renameResult.getNumber() == NicknamePokemonResponse.Result.UNSET_VALUE);
             if (isSkipped) {
-                System.out.println("Skipped renaming "
-                        + PokeHandler.getLocalPokeName(pokemon)
-                        + ", already named "
-                        + pokemon.getNickname());
+                System.out.println(String.format("Skipped renaming %s, already named %s",
+                        PokeHandler.getLocalPokeName(pokemon),
+                        pokemon.getNickname()));
                 skipped.increment();
                 return;
             }
@@ -266,18 +265,21 @@ public class PokemonTab extends JPanel {
             if (renameResult.getNumber() == NicknamePokemonResponse.Result.SUCCESS_VALUE) {
                 success.increment();
                 if (pokeNick.isTooLong()) {
-                    System.out.println("WARNING: Nickname \"" + pokeNick.fullNickname
-                            + "\" is too long. Get's cut to: " + pokeNick.toString());
+                    System.out.println(String.format(
+                            "WARNING: Nickname \"%s\" is too long. Get's cut to: %s",
+                            pokeNick.fullNickname,
+                            pokeNick.toString()));
                 }
-                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon)
-                        + " from \"" + pokemon.getNickname()
-                        + "\" to \"" + PokeHandler.generatePokemonNickname(renamePattern, pokemon)
-                        + "\", Result: Success!");
+                System.out.println(String.format("Renaming %s from \"%s\" to \"%s\", Result: Success!",
+                        PokeHandler.getLocalPokeName(pokemon),
+                        pokemon.getNickname(),
+                        PokeHandler.generatePokemonNickname(renamePattern, pokemon)));
             } else {
                 err.increment();
-                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon)
-                        + " failed! Code: " + renameResult.toString()
-                        + "; Nick: " + PokeHandler.generatePokemonNickname(renamePattern, pokemon));
+                System.out.println(String.format("Renaming %s failed! Code: %s; Nick: %s",
+                        PokeHandler.getLocalPokeName(pokemon),
+                        renameResult.toString(),
+                        PokeHandler.generatePokemonNickname(renamePattern, pokemon)));
             }
 
             // If not last element and API was queried, sleep until the next one
@@ -758,8 +760,7 @@ public class PokemonTab extends JPanel {
     }
 
     /**
-     * Provide custom formatting for the moveset ranking columns while allowing
-     * sorting on original values
+     * Provide custom formatting for the moveset ranking columns while allowing sorting on original values
      */
     public static class MoveSetRankingRenderer extends JLabel implements TableCellRenderer {
 

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -1,6 +1,5 @@
 package me.corriekay.pokegoutil.windows;
 
-import POGOProtos.Enums.PokemonFamilyIdOuterClass.PokemonFamilyId;
 import POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
 import POGOProtos.Networking.Responses.NicknamePokemonResponseOuterClass.NicknamePokemonResponse;
 import POGOProtos.Networking.Responses.ReleasePokemonResponseOuterClass;
@@ -10,26 +9,23 @@ import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.api.map.pokemon.EvolutionResult;
 import com.pokegoapi.api.player.PlayerProfile.Currency;
 import com.pokegoapi.api.pokemon.Pokemon;
-import com.pokegoapi.api.pokemon.PokemonMeta;
-import com.pokegoapi.api.pokemon.PokemonMetaRegistry;
+
 import me.corriekay.pokegoutil.utils.ConfigKey;
 import me.corriekay.pokegoutil.utils.ConfigNew;
 import me.corriekay.pokegoutil.utils.Utilities;
-import me.corriekay.pokegoutil.utils.helpers.DateHelper;
-import me.corriekay.pokegoutil.utils.helpers.JTableColumnPacker;
 import me.corriekay.pokegoutil.utils.helpers.LDocumentListener;
 import me.corriekay.pokegoutil.utils.pokemon.PokeHandler;
 import me.corriekay.pokegoutil.utils.pokemon.PokeNick;
-import me.corriekay.pokegoutil.utils.pokemon.PokemonCpUtils;
 import me.corriekay.pokegoutil.utils.pokemon.PokemonUtils;
 import me.corriekay.pokegoutil.utils.ui.GhostText;
+import me.corriekay.pokegoutil.utils.windows.PokemonTable;
+import me.corriekay.pokegoutil.utils.windows.PokemonTableModel;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
-import org.apache.commons.lang3.text.WordUtils;
 
 import javax.swing.*;
-import javax.swing.RowSorter.SortKey;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.*;
@@ -45,7 +41,7 @@ import java.util.function.BiConsumer;
 public class PokemonTab extends JPanel {
 
     private final PokemonGo go;
-    private final PokemonTable pt = new PokemonTable();
+    private final PokemonTable pt;
     private final JTextField searchBar = new JTextField("");
     private final JTextField ivTransfer = new JTextField("", 20);
 
@@ -54,6 +50,7 @@ public class PokemonTab extends JPanel {
     public PokemonTab(PokemonGo go) {
         setLayout(new BorderLayout());
         this.go = go;
+        pt = new PokemonTable(go);
         JPanel topPanel = new JPanel(new GridBagLayout());
         JButton refreshPkmn, renameSelected, transferSelected, evolveSelected, powerUpSelected, toggleFavorite;
         refreshPkmn = new JButton("Refresh List");
@@ -136,15 +133,14 @@ public class PokemonTab extends JPanel {
 
                     @Override
                     public void keyTyped(KeyEvent e) {
-                        //nothing here
+                        // nothing here
                     }
 
                     @Override
                     public void keyReleased(KeyEvent e) {
-                        //nothing here
+                        // nothing here
                     }
-                }
-        );
+                });
 
         topPanel.add(ivTransfer, gbc);
 
@@ -165,7 +161,7 @@ public class PokemonTab extends JPanel {
         topPanel.add(searchBar, gbc);
 
         // pokemon name language drop down
-        String[] locales = {"en", "de", "fr", "ru", "zh_CN", "zh_HK", "ja"};
+        String[] locales = { "en", "de", "fr", "ru", "zh_CN", "zh_HK", "ja" };
         JComboBox<String> pokelang = new JComboBox<>(locales);
         String locale = config.getString(ConfigKey.LANGUAGE);
         pokelang.setSelectedItem(locale);
@@ -188,7 +184,7 @@ public class PokemonTab extends JPanel {
         }
 
         // Font size dropdown
-        String[] sizes = {"11", "12", "13", "14", "15", "16", "17", "18"};
+        String[] sizes = { "11", "12", "13", "14", "15", "16", "17", "18" };
         JComboBox<String> fontSize = new JComboBox<>(sizes);
         fontSize.setSelectedItem(String.valueOf(size));
         fontSize.addActionListener(e -> new SwingWorker<Void, Void>() {
@@ -243,10 +239,12 @@ public class PokemonTab extends JPanel {
 
     private void renameSelected() {
         ArrayList<Pokemon> selection = getSelectedPokemon();
-        if (selection.size() == 0) return;
+        if (selection.size() == 0)
+            return;
         String renamePattern = inputOperation("Rename", selection);
 
-        MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(), total = new MutableInt(1);
+        MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+                total = new MutableInt(1);
         PokeHandler handler = new PokeHandler(selection);
 
         BiConsumer<NicknamePokemonResponse.Result, Pokemon> perPokeCallback = (renameResult, pokemon) -> {
@@ -259,7 +257,8 @@ public class PokemonTab extends JPanel {
             boolean isSkipped = (pokeNick.equals(pokemon.getNickname())
                     && renameResult.getNumber() == NicknamePokemonResponse.Result.UNSET_VALUE);
             if (isSkipped) {
-                System.out.println("Skipped renaming " + PokeHandler.getLocalPokeName(pokemon) + ", already named " + pokemon.getNickname());
+                System.out.println("Skipped renaming " + PokeHandler.getLocalPokeName(pokemon) + ", already named "
+                        + pokemon.getNickname());
                 skipped.increment();
                 return;
             }
@@ -267,12 +266,17 @@ public class PokemonTab extends JPanel {
             if (renameResult.getNumber() == NicknamePokemonResponse.Result.SUCCESS_VALUE) {
                 success.increment();
                 if (pokeNick.isTooLong()) {
-                    System.out.println("WARNING: Nickname \"" + pokeNick.fullNickname + "\" is too long. Get's cut to: " + pokeNick.toString());
+                    System.out.println("WARNING: Nickname \"" + pokeNick.fullNickname + "\" is too long. Get's cut to: "
+                            + pokeNick.toString());
                 }
-                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " from \"" + pokemon.getNickname() + "\" to \"" + PokeHandler.generatePokemonNickname(renamePattern, pokemon) + "\", Result: Success!");
+                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " from \""
+                        + pokemon.getNickname() + "\" to \""
+                        + PokeHandler.generatePokemonNickname(renamePattern, pokemon) + "\", Result: Success!");
             } else {
                 err.increment();
-                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " failed! Code: " + renameResult.toString() + "; Nick: " + PokeHandler.generatePokemonNickname(renamePattern, pokemon));
+                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " failed! Code: "
+                        + renameResult.toString() + "; Nick: "
+                        + PokeHandler.generatePokemonNickname(renamePattern, pokemon));
             }
 
             // If not last element and API was queried, sleep until the next one
@@ -296,34 +300,41 @@ public class PokemonTab extends JPanel {
 
     private void transferSelected() {
         ArrayList<Pokemon> selection = getSelectedPokemon();
-        if (selection.size() == 0) return;
+        if (selection.size() == 0)
+            return;
         if (confirmOperation("Transfer", selection)) {
-            MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(), total = new MutableInt(1);
+            MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+                    total = new MutableInt(1);
             selection.forEach(poke -> {
                 System.out.println("Doing Transfer " + total.getValue() + " of " + selection.size());
                 total.increment();
                 if (poke.isFavorite()) {
-                    System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp() + " CP is favorite, skipping.");
+                    System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp()
+                            + " CP is favorite, skipping.");
                     skipped.increment();
                     return;
                 }
                 if (!poke.getDeployedFortId().isEmpty()) {
-                    System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp() + " CP is in gym, skipping.");
+                    System.out.println(
+                            PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp() + " CP is in gym, skipping.");
                     skipped.increment();
                     return;
                 }
 
                 try {
                     int candies = poke.getCandy();
-                    ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result transferResult = poke.transferPokemon();
+                    ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result transferResult = poke
+                            .transferPokemon();
 
                     if (transferResult == ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result.SUCCESS) {
                         int newCandies = poke.getCandy();
                         System.out.println("Transferring " + PokeHandler.getLocalPokeName(poke) + ", Result: Success!");
-                        System.out.println("Stat changes: (Candies : " + newCandies + "[+" + (newCandies - candies) + "])");
+                        System.out.println(
+                                "Stat changes: (Candies : " + newCandies + "[+" + (newCandies - candies) + "])");
                         success.increment();
                     } else {
-                        System.out.println("Error transferring " + PokeHandler.getLocalPokeName(poke) + ", result: " + transferResult.toString());
+                        System.out.println("Error transferring " + PokeHandler.getLocalPokeName(poke) + ", result: "
+                                + transferResult.toString());
                         err.increment();
                     }
 
@@ -335,7 +346,8 @@ public class PokemonTab extends JPanel {
                     }
                 } catch (Exception e) {
                     err.increment();
-                    System.out.println("Error transferring " + PokeHandler.getLocalPokeName(poke) + "! " + Utilities.getRealExceptionMessage(e));
+                    System.out.println("Error transferring " + PokeHandler.getLocalPokeName(poke) + "! "
+                            + Utilities.getRealExceptionMessage(e));
                 }
             });
             try {
@@ -352,12 +364,14 @@ public class PokemonTab extends JPanel {
         ArrayList<Pokemon> selection = getSelectedPokemon();
         if (selection.size() > 0) {
             if (confirmOperation("Evolve", selection)) {
-                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(), total = new MutableInt(1);
+                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+                        total = new MutableInt(1);
                 selection.forEach(poke -> {
                     System.out.println("Doing Evolve " + total.getValue() + " of " + selection.size());
                     total.increment();
                     if (!poke.getDeployedFortId().isEmpty()) {
-                        System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp() + " CP is in gym, skipping.");
+                        System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp()
+                                + " CP is in gym, skipping.");
                         skipped.increment();
                         return;
                     }
@@ -368,10 +382,12 @@ public class PokemonTab extends JPanel {
                         int cp = poke.getCp();
                         int hp = poke.getMaxStamina();
 
-                        // Check if user has enough candy, otherwise we don't need to call server
+                        // Check if user has enough candy, otherwise we don't
+                        // need to call server
                         if (candies < candiesToEvolve) {
                             err.increment();
-                            System.out.println("Error. Not enough candy to evolve " + PokeHandler.getLocalPokeName(poke) + ". " + candies + " available, " + candiesToEvolve + " needed.");
+                            System.out.println("Error. Not enough candy to evolve " + PokeHandler.getLocalPokeName(poke)
+                                    + ". " + candies + " available, " + candiesToEvolve + " needed.");
                             return;
                         }
 
@@ -381,19 +397,27 @@ public class PokemonTab extends JPanel {
                             int newCandies = newPoke.getCandy();
                             int newCp = newPoke.getCp();
                             int newHp = newPoke.getStamina();
-                            System.out.println("Evolving " + PokeHandler.getLocalPokeName(poke) + ". Evolve result: " + evolutionResultWrapper.getResult().toString());
+                            System.out.println("Evolving " + PokeHandler.getLocalPokeName(poke) + ". Evolve result: "
+                                    + evolutionResultWrapper.getResult().toString());
                             if (config.getBool(ConfigKey.TRANSFER_AFTER_EVOLVE)) {
-                                ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result result = newPoke.transferPokemon();
-                                System.out.println("Transferring " + StringUtils.capitalize(newPoke.getPokemonId().toString().toLowerCase()) + ", Result: " + result);
-                                System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "]");
+                                ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result result = newPoke
+                                        .transferPokemon();
+                                System.out.println("Transferring "
+                                        + StringUtils.capitalize(newPoke.getPokemonId().toString().toLowerCase())
+                                        + ", Result: " + result);
+                                System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-"
+                                        + candiesToEvolve + "]");
                             } else {
-                                System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp + "[+" + (newHp - hp) + "])");
+                                System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-"
+                                        + candiesToEvolve + "], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp
+                                        + "[+" + (newHp - hp) + "])");
                             }
                             go.getInventories().updateInventories(true);
                             success.increment();
                         } else {
                             err.increment();
-                            System.out.println("Error evolving " + PokeHandler.getLocalPokeName(poke) + ", result: " + evolutionResultWrapper.getResult().toString());
+                            System.out.println("Error evolving " + PokeHandler.getLocalPokeName(poke) + ", result: "
+                                    + evolutionResultWrapper.getResult().toString());
                         }
 
                         // If not last element, sleep until the next one
@@ -404,7 +428,8 @@ public class PokemonTab extends JPanel {
                         }
                     } catch (Exception e) {
                         err.increment();
-                        System.out.println("Error evolving " + PokeHandler.getLocalPokeName(poke) + "! " + Utilities.getRealExceptionMessage(e));
+                        System.out.println("Error evolving " + PokeHandler.getLocalPokeName(poke) + "! "
+                                + Utilities.getRealExceptionMessage(e));
                     }
                 });
                 try {
@@ -424,13 +449,15 @@ public class PokemonTab extends JPanel {
         ArrayList<Pokemon> selection = getSelectedPokemon();
         if (selection.size() > 0) {
             if (confirmOperation("PowerUp", selection)) {
-                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(), total = new MutableInt(1);
+                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+                        total = new MutableInt(1);
                 selection.forEach(poke -> {
                     try {
                         System.out.println("Doing Power Up " + total.getValue() + " of " + selection.size());
                         total.increment();
                         if (!poke.getDeployedFortId().isEmpty()) {
-                            System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp() + " CP is in gym, skipping.");
+                            System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp()
+                                    + " CP is in gym, skipping.");
                             skipped.increment();
                             return;
                         }
@@ -442,10 +469,13 @@ public class PokemonTab extends JPanel {
                         int stardustToPowerUp = poke.getStardustCostsForPowerup();
                         int candiesToPowerUp = poke.getCandyCostsForPowerup();
 
-                        // Check if user has enough candy and stardust, otherwise we don't need to call server
+                        // Check if user has enough candy and stardust,
+                        // otherwise we don't need to call server
                         if (candies < candiesToPowerUp || stardust < stardustToPowerUp) {
                             err.increment();
-                            System.out.println("Error. Not enough candy/stardust to power up " + PokeHandler.getLocalPokeName(poke) + ". Stardust: " + stardust + "/" + stardustToPowerUp + ", Candy: " + candies + "/" + candiesToPowerUp);
+                            System.out.println("Error. Not enough candy/stardust to power up "
+                                    + PokeHandler.getLocalPokeName(poke) + ". Stardust: " + stardust + "/"
+                                    + stardustToPowerUp + ", Candy: " + candies + "/" + candiesToPowerUp);
                             return;
                         }
 
@@ -455,12 +485,17 @@ public class PokemonTab extends JPanel {
                             int newCandies = poke.getCandy();
                             int newCp = poke.getCp();
                             int newHp = poke.getMaxStamina();
-                            System.out.println("Powering Up " + PokeHandler.getLocalPokeName(poke) + ", Result: Success!");
-                            System.out.println("Stat changes: (Candies : " + newCandies + "[" + candies + "-" + candiesToPowerUp + "], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp + "[+" + (newHp - hp) + "]) Stardust used " + stardustToPowerUp + "[remaining: " + go.getPlayerProfile().getCurrency(Currency.STARDUST) + "]");
+                            System.out.println(
+                                    "Powering Up " + PokeHandler.getLocalPokeName(poke) + ", Result: Success!");
+                            System.out.println("Stat changes: (Candies : " + newCandies + "[" + candies + "-"
+                                    + candiesToPowerUp + "], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp
+                                    + "[+" + (newHp - hp) + "]) Stardust used " + stardustToPowerUp + "[remaining: "
+                                    + go.getPlayerProfile().getCurrency(Currency.STARDUST) + "]");
                             success.increment();
                         } else {
                             err.increment();
-                            System.out.println("Error powering up " + PokeHandler.getLocalPokeName(poke) + ", result: " + upgradeResult.toString());
+                            System.out.println("Error powering up " + PokeHandler.getLocalPokeName(poke) + ", result: "
+                                    + upgradeResult.toString());
                         }
 
                         // If not last element, sleep until the next one
@@ -471,7 +506,8 @@ public class PokemonTab extends JPanel {
                         }
                     } catch (Exception e) {
                         err.increment();
-                        System.out.println("Error powering up " + PokeHandler.getLocalPokeName(poke) + "! " + Utilities.getRealExceptionMessage(e));
+                        System.out.println("Error powering up " + PokeHandler.getLocalPokeName(poke) + "! "
+                                + Utilities.getRealExceptionMessage(e));
                     }
                 });
                 try {
@@ -486,26 +522,31 @@ public class PokemonTab extends JPanel {
         }
     }
 
-    //feature added by Ben Kauffman
+    // feature added by Ben Kauffman
     private void toggleFavorite() {
         ArrayList<Pokemon> selection = getSelectedPokemon();
         if (selection.size() > 0) {
             if (confirmOperation("Toggle Favorite", selection)) {
-                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(), total = new MutableInt(1);
+                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+                        total = new MutableInt(1);
                 selection.forEach(poke -> {
                     try {
                         System.out.println("Toggling favorite " + total.getValue() + " of " + selection.size());
                         total.increment();
-                        SetFavoritePokemonResponseOuterClass.SetFavoritePokemonResponse.Result favoriteResult = poke.setFavoritePokemon(!poke.isFavorite());
-                        System.out.println("Attempting to set favorite for " + PokeHandler.getLocalPokeName(poke) + " to " + !poke.isFavorite() + "...");
+                        SetFavoritePokemonResponseOuterClass.SetFavoritePokemonResponse.Result favoriteResult = poke
+                                .setFavoritePokemon(!poke.isFavorite());
+                        System.out.println("Attempting to set favorite for " + PokeHandler.getLocalPokeName(poke)
+                                + " to " + !poke.isFavorite() + "...");
                         go.getPlayerProfile().updateProfile();
 
                         if (favoriteResult == SetFavoritePokemonResponseOuterClass.SetFavoritePokemonResponse.Result.SUCCESS) {
-                            System.out.println("Favorite for " + PokeHandler.getLocalPokeName(poke) + " set to " + !poke.isFavorite() + ", Result: Success!");
+                            System.out.println("Favorite for " + PokeHandler.getLocalPokeName(poke) + " set to "
+                                    + !poke.isFavorite() + ", Result: Success!");
                             success.increment();
                         } else {
                             err.increment();
-                            System.out.println("Error toggling favorite for " + PokeHandler.getLocalPokeName(poke) + ", result: " + favoriteResult.toString());
+                            System.out.println("Error toggling favorite for " + PokeHandler.getLocalPokeName(poke)
+                                    + ", result: " + favoriteResult.toString());
                         }
 
                         // If not last element, sleep until the next one
@@ -516,7 +557,8 @@ public class PokemonTab extends JPanel {
                         }
                     } catch (Exception e) {
                         err.increment();
-                        System.out.println("Error toggling favorite for " + PokeHandler.getLocalPokeName(poke) + "! " + Utilities.getRealExceptionMessage(e));
+                        System.out.println("Error toggling favorite for " + PokeHandler.getLocalPokeName(poke) + "! "
+                                + Utilities.getRealExceptionMessage(e));
                     }
                 });
                 try {
@@ -525,7 +567,8 @@ public class PokemonTab extends JPanel {
                     e.printStackTrace();
                 }
                 SwingUtilities.invokeLater(this::refreshPkmn);
-                showFinishedText("Pokémon batch \"toggle favorite\" complete!", selection.size(), success, skipped, err);
+                showFinishedText("Pokémon batch \"toggle favorite\" complete!", selection.size(), success, skipped,
+                        err);
             }
         }
     }
@@ -543,8 +586,9 @@ public class PokemonTab extends JPanel {
         }
         pt.clearSelection();
         System.out.println("Selecting Pokemon with IV less than: " + ivTransfer.getText());
+        
         for (int i = 0; i < pt.getRowCount(); i++) {
-            double pIv = (double) pt.getValueAt(i, 3);
+            double pIv = Double.parseDouble((String) pt.getValueAt(i,3));
             if (pIv < ivLessThan) {
                 pt.getSelectionModel().addSelectionInterval(i, i);
             }
@@ -555,12 +599,13 @@ public class PokemonTab extends JPanel {
         JPanel panel = _buildPanelForOperation(operation, pokes);
         String message = "";
         switch (operation) {
-            case "Rename":
-                message = "You want to rename " + pokes.size() + " Pokémon.\nYou can rename with normal text and patterns, or both combined. Patterns are going to be replaced with the Pokémons values.\nExisting patterns:\n";
-                for (PokeHandler.ReplacePattern pattern : PokeHandler.ReplacePattern.values()) {
-                    message += "%" + pattern.name().toLowerCase() + "% -> " + pattern.toString() + "\n";
-                }
-                message += "\n";
+        case "Rename":
+            message = "You want to rename " + pokes.size()
+                    + " Pokémon.\nYou can rename with normal text and patterns, or both combined. Patterns are going to be replaced with the Pokémons values.\nExisting patterns:\n";
+            for (PokeHandler.ReplacePattern pattern : PokeHandler.ReplacePattern.values()) {
+                message += "%" + pattern.name().toLowerCase() + "% -> " + pattern.toString() + "\n";
+            }
+            message += "\n";
         }
 
         String input = JOptionPane.showInputDialog(panel, message, operation, JOptionPane.PLAIN_MESSAGE);
@@ -590,7 +635,8 @@ public class PokemonTab extends JPanel {
         // Auto-height? Resizable? Haha. Funny joke.
         // I hate swing. But we need to get around here some way.
         // So lets get dirty.
-        // We take 20 px for each row, 5 px buffer, and cap that at may 400 pixel.
+        // We take 20 px for each row, 5 px buffer, and cap that at may 400
+        // pixel.
         int height = Math.min(400, pokes.size() * 20 + 5);
         panel.setPreferredSize(new Dimension(500, height));
 
@@ -598,19 +644,19 @@ public class PokemonTab extends JPanel {
             String str = PokeHandler.getLocalPokeName(p) + " - CP: " + p.getCp() + ", IV: "
                     + Utilities.percentageWithTwoCharacters(PokemonUtils.ivRating(p)) + "%";
             switch (operation) {
-                case "Evolve":
-                    str += " Cost: " + p.getCandiesToEvolve();
-                    str += p.getCandiesToEvolve() > 1 ? " Candies" : " Candy";
-                    break;
-                case "PowerUp":
-                    str += " Cost: " + p.getCandyCostsForPowerup();
-                    str += p.getCandyCostsForPowerup() > 1 ? " Candies" : " Candy";
-                    str += " " + p.getStardustCostsForPowerup() + " Stardust";
-                    break;
-                case "Rename":
-                    break;
-                case "Transfer":
-                    break;
+            case "Evolve":
+                str += " Cost: " + p.getCandiesToEvolve();
+                str += p.getCandiesToEvolve() > 1 ? " Candies" : " Candy";
+                break;
+            case "PowerUp":
+                str += " Cost: " + p.getCandyCostsForPowerup();
+                str += p.getCandyCostsForPowerup() > 1 ? " Candies" : " Candy";
+                str += " " + p.getStardustCostsForPowerup() + " Stardust";
+                break;
+            case "Rename":
+                break;
+            case "Transfer":
+                break;
             }
             innerPanel.add(new JLabel(str));
         });
@@ -632,7 +678,8 @@ public class PokemonTab extends JPanel {
 
     public void refreshList() {
         List<Pokemon> pokes = new ArrayList<>();
-        String search = searchBar.getText().replaceAll(" ", "").replaceAll("_", "").replaceAll("snek", "ekans").toLowerCase();
+        String search = searchBar.getText().replaceAll(" ", "").replaceAll("_", "").replaceAll("snek", "ekans")
+                .toLowerCase();
         String[] terms = search.split(";");
         try {
             go.getInventories().getPokebank().getPokemons().forEach(poke -> {
@@ -641,51 +688,63 @@ public class PokemonTab extends JPanel {
                 if (useFamilyName) {
                     // Try translating family name
                     try {
-                        PokemonId familyPokemonId = PokemonId.valueOf(poke.getPokemonFamily().toString().replaceAll("FAMILY_", ""));
+                        PokemonId familyPokemonId = PokemonId
+                                .valueOf(poke.getPokemonFamily().toString().replaceAll("FAMILY_", ""));
                         familyName = PokeHandler.getLocalPokeName(familyPokemonId.getNumber());
                     } catch (IllegalArgumentException e) {
                         familyName = poke.getPokemonFamily().toString();
                     }
                 }
 
-                String searchme = PokeHandler.getLocalPokeName(poke)
-                        + ((useFamilyName) ? familyName : "")
-                        + poke.getNickname()
-                        + poke.getMeta().getType1() + poke.getMeta().getType2() + poke.getMove1() + poke.getMove2()
-                        + poke.getPokeball();
-                searchme = searchme.replaceAll("_FAST", "").replaceAll("FAMILY_", "").replaceAll("NONE", "").replaceAll("ITEM_", "").replaceAll("_", "").replaceAll(" ", "").toLowerCase();
+                String searchme = Utilities.concatString(',',
+                        PokeHandler.getLocalPokeName(poke).toString(),
+                        ((useFamilyName) ? familyName : ""),
+                        poke.getNickname().toString(),
+                        poke.getMeta().getType1().toString(),
+                        poke.getMeta().getType2().toString(),
+                        poke.getMove1().toString(),
+                        poke.getMove2().toString(),
+                        poke.getPokeball().toString());
+                searchme = searchme.replaceAll("_FAST", "").replaceAll("FAMILY_", "").replaceAll("NONE", "")
+                        .replaceAll("ITEM_", "").replaceAll("_", "").replaceAll(" ", "").toLowerCase();
+                
                 for (String s : terms) {
                     if (searchme.contains(s)) {
                         pokes.add(poke);
-                        // Break, so that a Pokémon isn't added twice even if it matches more than one criteria
+                        // Break, so that a Pokémon isn't added twice even if it
+                        // matches more than one criteria
                         break;
                     }
                 }
             });
-            pt.constructNewTableModel(go, (search.equals("") || search.equals("searchpokémon...")
+            pt.constructNewTableModel((search.equals("") || search.equals("searchpokémon...")
                     ? go.getInventories().getPokebank().getPokemons() : pokes));
-            for (int i = 0; i < pt.getModel().getColumnCount(); i++) {
-                JTableColumnPacker.packColumn(pt, i, 4);
-            }
+            
+           // for (int i = 0; i < pt.getModel().getColumnCount(); i++) {
+            //    JTableColumnPacker.packColumn(pt, i, 4);
+            //}
 
             // Custom cell renderers
-            // Magic numbers pulled from max values of their respective columns in the moveset rankings spreadsheet calculations
-            // @see https://www.reddit.com/r/TheSilphRoad/comments/4vcobt/posthotfix_pokemon_go_full_moveset_rankings/
-            TableColumn duelAbilityCol = this.pt.getColumnModel().getColumn(24);
-            duelAbilityCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.DUEL_ABILITY_MAX));
-            TableColumn gymAttackCol = this.pt.getColumnModel().getColumn(25);
-            gymAttackCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_OFFENSE_MAX));
-            TableColumn gymDefenseCol = this.pt.getColumnModel().getColumn(26);
-            gymDefenseCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_DEFENSE_MAX));
+            // Magic numbers pulled from max values of their respective columns
+            // in the moveset rankings spreadsheet calculations
+            // @see
+            // https://www.reddit.com/r/TheSilphRoad/comments/4vcobt/posthotfix_pokemon_go_full_moveset_rankings/
+            //TableColumn duelAbilityCol = this.pt.getColumnModel().getColumn(24);
+            //duelAbilityCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.DUEL_ABILITY_MAX));
+            //TableColumn gymAttackCol = this.pt.getColumnModel().getColumn(25);
+            //gymAttackCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_OFFENSE_MAX));
+            //TableColumn gymDefenseCol = this.pt.getColumnModel().getColumn(26);
+            //gymDefenseCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_DEFENSE_MAX));
         } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
     /**
-     * Provide custom formatting for the moveset ranking columns while allowing sorting on original values
+     * Provide custom formatting for the moveset ranking columns while allowing
+     * sorting on original values
      */
-    private static class MoveSetRankingRenderer extends JLabel implements TableCellRenderer {
+    public static class MoveSetRankingRenderer extends JLabel implements TableCellRenderer {
 
         private final long scale;
 
@@ -695,7 +754,7 @@ public class PokemonTab extends JPanel {
 
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
-                                                       boolean hasFocus, int rowIndex, int vColIndex) {
+                boolean hasFocus, int rowIndex, int vColIndex) {
             setText(Utilities.percentageWithTwoCharacters(Double.parseDouble(value.toString()), this.scale));
             setToolTipText(NumberFormat.getInstance().format(value));
             setOpaque(true);
@@ -711,452 +770,6 @@ public class PokemonTab extends JPanel {
         } else {
             tcr.setBackground(table.getBackground());
             tcr.setForeground(table.getForeground());
-        }
-    }
-
-    private static class PokemonTable extends JTable {
-
-        /**
-         * data types:
-         * 0 String - Nickname
-         * 1 Integer - Pokemon Number
-         * 2 String - Type / Pokemon
-         * 3 String(Percentage) - IV Rating
-         * 4 Double - Level
-         * 5 Integer - Attack
-         * 6 Integer - Defense
-         * 7 Integer - Stamina
-         * 8 String - Type 1
-         * 9 String - Type 2
-         * 10 String - Move 1
-         * 11 String - Move 2
-         * 12 Integer - CP
-         * 13 Integer - HP
-         * 14 Integer - Max CP (Current)
-         * 15 Integer - Max CP
-         * 16 Integer - Max Evolved CP (Current)
-         * 17 Integer - Max Evolved CP
-         * 18 Integer - Candies of type
-         * 19 String(Nullable Int) - Candies to Evolve
-         * 20 Integer - Star Dust to level
-         * 21 String - Pokeball Type
-         * 22 String(Date) - Caught at
-         * 23 Boolean - Favorite
-         * 24 Long - duelAbility
-         * 25 Integer - gymOffense
-         * 26 Integer - gymDefense
-         * 27 String(Percentage) - Move 1 Rating
-         * 28 String(Percentage) - Move 2 Rating
-         * 29 String(Nullable Int) - CP Evolved
-         * 30 String(Nullable Int) - Evolvable
-         */
-        ConfigNew config = ConfigNew.getConfig();
-
-        int sortColIndex1, sortColIndex2;
-        SortOrder sortOrder1, sortOrder2;
-
-        private PokemonTable() {
-            setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
-            setAutoResizeMode(AUTO_RESIZE_OFF);
-
-            // Load sort configs
-            sortColIndex1 = config.getInt(ConfigKey.SORT_COLINDEX_1);
-            sortColIndex2 = config.getInt(ConfigKey.SORT_COLINDEX_2);
-            try {
-                sortOrder1 = SortOrder.valueOf(config.getString(ConfigKey.SORT_ORDER_1));
-                sortOrder2 = SortOrder.valueOf(config.getString(ConfigKey.SORT_ORDER_2));
-            } catch (IllegalArgumentException e) {
-                e.printStackTrace();
-                sortOrder1 = SortOrder.ASCENDING;
-                sortOrder2 = SortOrder.ASCENDING;
-            }
-        }
-
-        private void constructNewTableModel(PokemonGo go, List<Pokemon> pokes) {
-            PokemonTableModel ptm = new PokemonTableModel(go, pokes, this);
-            setModel(ptm);
-            TableRowSorter<TableModel> trs = new TableRowSorter<>(getModel());
-            Comparator<Integer> c = Integer::compareTo;
-            Comparator<Double> cDouble = Double::compareTo;
-            Comparator<String> cDate = (date1, date2) -> DateHelper.fromString(date1).compareTo(DateHelper.fromString(date2));
-            Comparator<String> cNullableInt = (s1, s2) -> {
-                if ("-".equals(s1))
-                    s1 = "0";
-                if ("-".equals(s2))
-                    s2 = "0";
-                return Integer.parseInt(s1) - Integer.parseInt(s2);
-            };
-            Comparator<Long> cLong = Long::compareTo;
-            Comparator<String> cPercentageWithTwoCharacters = (s1, s2) -> {
-                int i1 = ("XX".equals(s1)) ? 100 : Integer.parseInt(s1);
-                int i2 = ("XX".equals(s2)) ? 100 : Integer.parseInt(s2);
-                return i1 - i2;
-            };
-            trs.setComparator(0, c);
-            trs.setComparator(3, cPercentageWithTwoCharacters);
-            trs.setComparator(4, cDouble);
-            trs.setComparator(5, c);
-            trs.setComparator(6, c);
-            trs.setComparator(7, c);
-            trs.setComparator(12, c);
-            trs.setComparator(13, c);
-            trs.setComparator(14, c);
-            trs.setComparator(15, c);
-            trs.setComparator(16, c);
-            trs.setComparator(17, c);
-            trs.setComparator(18, c);
-            trs.setComparator(19, cNullableInt);
-            trs.setComparator(20, c);
-            trs.setComparator(22, cDate);
-            trs.setComparator(24, cLong);
-            trs.setComparator(25, cLong);
-            trs.setComparator(26, cLong);
-            trs.setComparator(27, cPercentageWithTwoCharacters);
-            trs.setComparator(28, cPercentageWithTwoCharacters);
-            trs.setComparator(29, cNullableInt);
-            trs.setComparator(30, cNullableInt);
-            setRowSorter(trs);
-            List<SortKey> sortKeys = new ArrayList<>();
-            sortKeys.add(new SortKey(sortColIndex1, sortOrder1));
-            sortKeys.add(new SortKey(sortColIndex2, sortOrder2));
-            trs.setSortKeys(sortKeys);
-
-            // Add listener to save those sorting values
-            trs.addRowSorterListener(
-                    e -> {
-                        RowSorter sorter = e.getSource();
-                        if (sorter != null) {
-                            List<SortKey> keys = sorter.getSortKeys();
-                            if (keys.size() > 0) {
-                                SortKey prim = keys.get(0);
-                                sortOrder1 = prim.getSortOrder();
-                                config.setString(ConfigKey.SORT_ORDER_1, sortOrder1.toString());
-                                sortColIndex1 = prim.getColumn();
-                                config.setInt(ConfigKey.SORT_COLINDEX_1, sortColIndex1);
-                            }
-                            if (keys.size() > 1) {
-                                SortKey sec = keys.get(1);
-                                sortOrder2 = sec.getSortOrder();
-                                config.setString(ConfigKey.SORT_ORDER_2, sortOrder2.toString());
-                                sortColIndex2 = sec.getColumn();
-                                config.setInt(ConfigKey.SORT_COLINDEX_2, sortColIndex2);
-                            }
-                        }
-                    });
-        }
-    }
-
-    private static class PokemonTableModel extends AbstractTableModel {
-
-        PokemonTable pt;
-
-        private final ArrayList<Pokemon> pokeCol = new ArrayList<>();
-        private final ArrayList<Integer> numIdCol = new ArrayList<>();//0
-        private final ArrayList<String> nickCol = new ArrayList<>(),//1
-                speciesCol = new ArrayList<>(),//2
-                ivCol = new ArrayList<>();//3
-        private final ArrayList<Double> levelCol = new ArrayList<>();//4
-        private final ArrayList<Integer> atkCol = new ArrayList<>(),//5
-                defCol = new ArrayList<>(),//6
-                stamCol = new ArrayList<>();//7
-        private final ArrayList<String> type1Col = new ArrayList<>(),//8
-                type2Col = new ArrayList<>(),//9
-                move1Col = new ArrayList<>(),//10
-                move2Col = new ArrayList<>();//11
-        private final ArrayList<Integer> cpCol = new ArrayList<>(),//12
-                hpCol = new ArrayList<>(),//13
-                maxCpCurrentCol = new ArrayList<>(),//14
-                maxCpCol = new ArrayList<>(),//15
-                maxEvolvedCpCurrentCol = new ArrayList<>(),//16
-                maxEvolvedCpCol = new ArrayList<>(),//17
-                candiesCol = new ArrayList<>();//18
-        private final ArrayList<String> candies2EvlvCol = new ArrayList<>();//19
-        private final ArrayList<Integer> dustToLevelCol = new ArrayList<>();//20
-        private final ArrayList<String> pokeballCol = new ArrayList<>(),//21
-                caughtCol = new ArrayList<>(),//22
-                favCol = new ArrayList<>();//23
-        private final ArrayList<Long> duelAbilityCol = new ArrayList<>();//24
-        private final ArrayList<Long> gymOffenseCol = new ArrayList<>();//25
-        private final ArrayList<Long> gymDefenseCol = new ArrayList<>();//26
-        private final ArrayList<String> move1RatingCol = new ArrayList<>(),//27
-                move2RatingCol = new ArrayList<>();//28
-        private final ArrayList<String> cpEvolvedCol = new ArrayList<>(),//29
-                evolvableCol = new ArrayList<>();//30
-
-        @Deprecated
-        private PokemonTableModel(PokemonGo go, List<Pokemon> pokes, PokemonTable pt) {
-            this.pt = pt;
-            MutableInt i = new MutableInt();
-            pokes.forEach(p -> {
-                pokeCol.add(i.getValue(), p);
-                numIdCol.add(i.getValue(), p.getMeta().getNumber());
-                nickCol.add(i.getValue(), p.getNickname());
-                speciesCol.add(i.getValue(),
-                        PokeHandler.getLocalPokeName(p));
-                levelCol.add(i.getValue(), (double) p.getLevel());
-                ivCol.add(i.getValue(), Utilities.percentageWithTwoCharacters(PokemonUtils.ivRating(p)));
-                cpCol.add(i.getValue(), p.getCp());
-                atkCol.add(i.getValue(), p.getIndividualAttack());
-                defCol.add(i.getValue(), p.getIndividualDefense());
-                stamCol.add(i.getValue(), p.getIndividualStamina());
-                type1Col.add(i.getValue(), StringUtils.capitalize(p.getMeta().getType1().toString().toLowerCase()));
-                type2Col.add(i.getValue(), StringUtils.capitalize(p.getMeta().getType2().toString().toLowerCase().replaceAll("none", "")));
-
-                Double dps1 = PokemonUtils.dpsForMove(p, true);
-                Double dps2 = PokemonUtils.dpsForMove(p, false);
-
-                move1Col.add(i.getValue(), WordUtils.capitalize(p.getMove1().toString().toLowerCase().replaceAll("_fast", "").replaceAll("_", " ")) + " (" + String.format("%.2f", dps1) + "dps)");
-                move2Col.add(i.getValue(), WordUtils.capitalize(p.getMove2().toString().toLowerCase().replaceAll("_", " ")) + " (" + String.format("%.2f", dps2) + "dps)");
-                hpCol.add(i.getValue(), p.getMaxStamina());
-
-                int trainerLevel = 1;
-                try {
-                    trainerLevel = go.getPlayerProfile().getStats().getLevel();
-                } catch (Exception e1) {
-                    e1.printStackTrace();
-                }
-
-                // Max CP calculation for current Pokemon
-                PokemonMeta pokemonMeta = PokemonMetaRegistry.getMeta(p.getPokemonId());
-                int maxCpCurrent = 0, maxCp = 0;
-                if (pokemonMeta == null) {
-                    System.out.println("Error: Cannot find meta data for " + p.getPokemonId().name());
-                } else {
-                    int attack = p.getIndividualAttack() + pokemonMeta.getBaseAttack();
-                    int defense = p.getIndividualDefense() + pokemonMeta.getBaseDefense();
-                    int stamina = p.getIndividualStamina() + pokemonMeta.getBaseStamina();
-                    maxCpCurrent = PokemonCpUtils.getMaxCpForTrainerLevel(attack, defense, stamina, trainerLevel);
-                    maxCp = PokemonCpUtils.getMaxCp(attack, defense, stamina);
-                    maxCpCurrentCol.add(i.getValue(), maxCpCurrent);
-                    maxCpCol.add(i.getValue(), maxCp);
-                }
-
-                // Max CP calculation for highest evolution of current Pokemon
-                PokemonFamilyId familyId = p.getPokemonFamily();
-                PokemonId highestFamilyId = PokemonMetaRegistry.getHightestForFamily(familyId);
-
-                // Eeveelutions exception handling
-                if (familyId.getNumber() == PokemonFamilyId.FAMILY_EEVEE.getNumber()) {
-                    if (p.getPokemonId().getNumber() == PokemonId.EEVEE.getNumber()) {
-                        PokemonMeta vap = PokemonMetaRegistry.getMeta(PokemonId.VAPOREON);
-                        PokemonMeta fla = PokemonMetaRegistry.getMeta(PokemonId.FLAREON);
-                        PokemonMeta jol = PokemonMetaRegistry.getMeta(PokemonId.JOLTEON);
-                        if (vap != null && fla != null && jol != null) {
-                            Comparator<PokemonMeta> cMeta = (m1, m2) -> {
-                                int comb1 = PokemonCpUtils.getMaxCp(m1.getBaseAttack(), m1.getBaseDefense(), m1.getBaseStamina());
-                                int comb2 = PokemonCpUtils.getMaxCp(m2.getBaseAttack(), m2.getBaseDefense(), m2.getBaseStamina());
-                                return comb1 - comb2;
-                            };
-                            highestFamilyId = PokemonId.forNumber(Collections.max(Arrays.asList(vap, fla, jol), cMeta).getNumber());
-                        }
-                    } else {
-                        // This is one of the eeveelutions, so PokemonMetaRegistry.getHightestForFamily() returns Eevee.
-                        // We correct that here
-                        highestFamilyId = p.getPokemonId();
-                    }
-                }
-
-                PokemonMeta highestFamilyMeta = PokemonMetaRegistry.getMeta(highestFamilyId);
-                if (highestFamilyId == p.getPokemonId()) {
-                    maxEvolvedCpCurrentCol.add(i.getValue(), maxCpCurrent);
-                    maxEvolvedCpCol.add(i.getValue(), maxCp);
-                    cpEvolvedCol.add(i.getValue(), "-");
-                } else if (highestFamilyMeta == null) {
-                    System.out.println("Error: Cannot find meta data for " + highestFamilyId.name());
-                } else {
-                    int attack = highestFamilyMeta.getBaseAttack() + p.getIndividualAttack();
-                    int defense = highestFamilyMeta.getBaseDefense() + p.getIndividualDefense();
-                    int stamina = highestFamilyMeta.getBaseStamina() + p.getIndividualStamina();
-                    maxEvolvedCpCurrentCol.add(i.getValue(), PokemonCpUtils.getMaxCpForTrainerLevel(attack, defense, stamina, trainerLevel));
-                    maxEvolvedCpCol.add(i.getValue(), PokemonCpUtils.getMaxCp(attack, defense, stamina));
-                    cpEvolvedCol.add(i.getValue(), String.valueOf(PokemonCpUtils.getCpForPokemonLevel(attack, defense, stamina, p.getLevel())));
-                }
-
-                int candies = 0;
-                try {
-                    candies = p.getCandy();
-                    candiesCol.add(i.getValue(), candies);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-                if (p.getCandiesToEvolve() != 0) {
-                    candies2EvlvCol.add(i.getValue(), String.valueOf(p.getCandiesToEvolve()));
-                    evolvableCol.add(i.getValue(), String.valueOf((int)((double) candies / p.getCandiesToEvolve()))); // Rounded down candies / toEvolve
-                }
-                else {
-                    candies2EvlvCol.add(i.getValue(), "-");
-                    evolvableCol.add(i.getValue(), "-");
-                }
-                dustToLevelCol.add(i.getValue(), p.getStardustCostsForPowerup());
-                pokeballCol.add(i.getValue(), WordUtils.capitalize(p.getPokeball().toString().toLowerCase().replaceAll("item_", "").replaceAll("_", " ")));
-                caughtCol.add(i.getValue(), DateHelper.toString(DateHelper.fromTimestamp(p.getCreationTimeMs())));
-                favCol.add(i.getValue(), (p.isFavorite()) ? "True" : "");
-                duelAbilityCol.add(i.getValue(), PokemonUtils.duelAbility(p));
-                gymOffenseCol.add(i.getValue(), PokemonUtils.gymOffense(p));
-                gymDefenseCol.add(i.getValue(), PokemonUtils.gymDefense(p));
-                move1RatingCol.add(i.getValue(), PokemonUtils.moveRating(p, true));
-                move2RatingCol.add(i.getValue(), PokemonUtils.moveRating(p, false));
-                i.increment();
-            });
-        }
-
-        private Pokemon getPokemonByIndex(int i) {
-            try {
-                return pokeCol.get(pt.convertRowIndexToModel(i));
-            } catch (Exception e) {
-                e.printStackTrace();
-                return null;
-            }
-        }
-
-        @Override
-        public String getColumnName(int columnIndex) {
-            switch (columnIndex) {
-                case 0:
-                    return "Id";
-                case 1:
-                    return "Nickname";
-                case 2:
-                    return "Species";
-                case 3:
-                    return "IV %";
-                case 4:
-                    return "Lvl";
-                case 5:
-                    return "Atk";
-                case 6:
-                    return "Def";
-                case 7:
-                    return "Stam";
-                case 8:
-                    return "Type 1";
-                case 9:
-                    return "Type 2";
-                case 10:
-                    return "Move 1";
-                case 11:
-                    return "Move 2";
-                case 12:
-                    return "CP";
-                case 13:
-                    return "HP";
-                case 14:
-                    return "Max CP (Cur)";
-                case 15:
-                    return "Max CP (40)";
-                case 16:
-                    return "Max Evolved CP (Cur)";
-                case 17:
-                    return "Max Evolved CP (40)";
-                case 18:
-                    return "Candies";
-                case 19:
-                    return "To Evolve";
-                case 20:
-                    return "Stardust";
-                case 21:
-                    return "Caught With";
-                case 22:
-                    return "Time Caught";
-                case 23:
-                    return "Favorite";
-                case 24:
-                    return "Duel Ability";
-                case 25:
-                    return "Gym Offense";
-                case 26:
-                    return "Gym Defense";
-                case 27:
-                    return "Move 1 Rating";
-                case 28:
-                    return "Move 2 Rating";
-                case 29:
-                    return "CP Evolved";
-                case 30:
-                    return "Evolvable";
-                default:
-                    return "UNKNOWN?";
-            }
-        }
-
-        @Override
-        public int getColumnCount() {
-            return 31;
-        }
-
-        @Override
-        public int getRowCount() {
-            return pokeCol.size();
-        }
-
-        @Override
-        public Object getValueAt(int rowIndex, int columnIndex) {
-            switch (columnIndex) {
-                case 0:
-                    return numIdCol.get(rowIndex);
-                case 1:
-                    return nickCol.get(rowIndex);
-                case 2:
-                    return speciesCol.get(rowIndex);
-                case 3:
-                    return ivCol.get(rowIndex);
-                case 4:
-                    return levelCol.get(rowIndex);
-                case 5:
-                    return atkCol.get(rowIndex);
-                case 6:
-                    return defCol.get(rowIndex);
-                case 7:
-                    return stamCol.get(rowIndex);
-                case 8:
-                    return type1Col.get(rowIndex);
-                case 9:
-                    return type2Col.get(rowIndex);
-                case 10:
-                    return move1Col.get(rowIndex);
-                case 11:
-                    return move2Col.get(rowIndex);
-                case 12:
-                    return cpCol.get(rowIndex);
-                case 13:
-                    return hpCol.get(rowIndex);
-                case 14:
-                    return maxCpCurrentCol.get(rowIndex);
-                case 15:
-                    return maxCpCol.get(rowIndex);
-                case 16:
-                    return maxEvolvedCpCurrentCol.get(rowIndex);
-                case 17:
-                    return maxEvolvedCpCol.get(rowIndex);
-                case 18:
-                    return candiesCol.get(rowIndex);
-                case 19:
-                    return candies2EvlvCol.get(rowIndex);
-                case 20:
-                    return dustToLevelCol.get(rowIndex);
-                case 21:
-                    return pokeballCol.get(rowIndex);
-                case 22:
-                    return caughtCol.get(rowIndex);
-                case 23:
-                    return favCol.get(rowIndex);
-                case 24:
-                    return duelAbilityCol.get(rowIndex);
-                case 25:
-                    return gymOffenseCol.get(rowIndex);
-                case 26:
-                    return gymDefenseCol.get(rowIndex);
-                case 27:
-                    return move1RatingCol.get(rowIndex);
-                case 28:
-                    return move2RatingCol.get(rowIndex);
-                case 29:
-                    return cpEvolvedCol.get(rowIndex);
-                case 30:
-                    return evolvableCol.get(rowIndex);
-                default:
-                    return null;
-            }
         }
     }
 }

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -243,7 +243,9 @@ public class PokemonTab extends JPanel {
             return;
         String renamePattern = inputOperation("Rename", selection);
 
-        MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+        MutableInt err = new MutableInt(),
+                skipped = new MutableInt(),
+                success = new MutableInt(),
                 total = new MutableInt(1);
         PokeHandler handler = new PokeHandler(selection);
 
@@ -257,7 +259,9 @@ public class PokemonTab extends JPanel {
             boolean isSkipped = (pokeNick.equals(pokemon.getNickname())
                     && renameResult.getNumber() == NicknamePokemonResponse.Result.UNSET_VALUE);
             if (isSkipped) {
-                System.out.println("Skipped renaming " + PokeHandler.getLocalPokeName(pokemon) + ", already named "
+                System.out.println("Skipped renaming "
+                        + PokeHandler.getLocalPokeName(pokemon)
+                        + ", already named "
                         + pokemon.getNickname());
                 skipped.increment();
                 return;
@@ -266,15 +270,22 @@ public class PokemonTab extends JPanel {
             if (renameResult.getNumber() == NicknamePokemonResponse.Result.SUCCESS_VALUE) {
                 success.increment();
                 if (pokeNick.isTooLong()) {
-                    System.out.println("WARNING: Nickname \"" + pokeNick.fullNickname + "\" is too long. Get's cut to: "
+                    System.out.println("WARNING: Nickname \""
+                            + pokeNick.fullNickname
+                            + "\" is too long. Get's cut to: "
                             + pokeNick.toString());
                 }
-                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " from \""
+                System.out.println("Renaming "
+                        + PokeHandler.getLocalPokeName(pokemon)
+                        + " from \""
                         + pokemon.getNickname() + "\" to \""
-                        + PokeHandler.generatePokemonNickname(renamePattern, pokemon) + "\", Result: Success!");
+                        + PokeHandler.generatePokemonNickname(renamePattern, pokemon)
+                        + "\", Result: Success!");
             } else {
                 err.increment();
-                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " failed! Code: "
+                System.out.println("Renaming "
+                        + PokeHandler.getLocalPokeName(pokemon)
+                        + " failed! Code: "
                         + renameResult.toString() + "; Nick: "
                         + PokeHandler.generatePokemonNickname(renamePattern, pokemon));
             }
@@ -303,20 +314,25 @@ public class PokemonTab extends JPanel {
         if (selection.size() == 0)
             return;
         if (confirmOperation("Transfer", selection)) {
-            MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+            MutableInt err = new MutableInt(),
+                    skipped = new MutableInt(),
+                    success = new MutableInt(),
                     total = new MutableInt(1);
             selection.forEach(poke -> {
                 System.out.println("Doing Transfer " + total.getValue() + " of " + selection.size());
                 total.increment();
                 if (poke.isFavorite()) {
-                    System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp()
+                    System.out.println(PokeHandler.getLocalPokeName(poke)
+                            + " with " + poke.getCp()
                             + " CP is favorite, skipping.");
                     skipped.increment();
                     return;
                 }
                 if (!poke.getDeployedFortId().isEmpty()) {
                     System.out.println(
-                            PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp() + " CP is in gym, skipping.");
+                            PokeHandler.getLocalPokeName(poke)
+                                    + " with " + poke.getCp()
+                                    + " CP is in gym, skipping.");
                     skipped.increment();
                     return;
                 }
@@ -330,10 +346,15 @@ public class PokemonTab extends JPanel {
                         int newCandies = poke.getCandy();
                         System.out.println("Transferring " + PokeHandler.getLocalPokeName(poke) + ", Result: Success!");
                         System.out.println(
-                                "Stat changes: (Candies : " + newCandies + "[+" + (newCandies - candies) + "])");
+                                "Stat changes: (Candies : "
+                                        + newCandies
+                                        + "[+" + (newCandies - candies)
+                                        + "])");
                         success.increment();
                     } else {
-                        System.out.println("Error transferring " + PokeHandler.getLocalPokeName(poke) + ", result: "
+                        System.out.println("Error transferring "
+                                + PokeHandler.getLocalPokeName(poke)
+                                + ", result: "
                                 + transferResult.toString());
                         err.increment();
                     }
@@ -346,7 +367,9 @@ public class PokemonTab extends JPanel {
                     }
                 } catch (Exception e) {
                     err.increment();
-                    System.out.println("Error transferring " + PokeHandler.getLocalPokeName(poke) + "! "
+                    System.out.println("Error transferring "
+                            + PokeHandler.getLocalPokeName(poke)
+                            + "! "
                             + Utilities.getRealExceptionMessage(e));
                 }
             });
@@ -364,13 +387,17 @@ public class PokemonTab extends JPanel {
         ArrayList<Pokemon> selection = getSelectedPokemon();
         if (selection.size() > 0) {
             if (confirmOperation("Evolve", selection)) {
-                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+                MutableInt err = new MutableInt(),
+                        skipped = new MutableInt(),
+                        success = new MutableInt(),
                         total = new MutableInt(1);
                 selection.forEach(poke -> {
-                    System.out.println("Doing Evolve " + total.getValue() + " of " + selection.size());
+                    System.out.println("Doing Evolve " + total.getValue()
+                            + " of " + selection.size());
                     total.increment();
                     if (!poke.getDeployedFortId().isEmpty()) {
-                        System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp()
+                        System.out.println(PokeHandler.getLocalPokeName(poke)
+                                + " with " + poke.getCp()
                                 + " CP is in gym, skipping.");
                         skipped.increment();
                         return;
@@ -386,8 +413,10 @@ public class PokemonTab extends JPanel {
                         // need to call server
                         if (candies < candiesToEvolve) {
                             err.increment();
-                            System.out.println("Error. Not enough candy to evolve " + PokeHandler.getLocalPokeName(poke)
-                                    + ". " + candies + " available, " + candiesToEvolve + " needed.");
+                            System.out.println("Error. Not enough candy to evolve "
+                                    + PokeHandler.getLocalPokeName(poke) + ". "
+                                    + candies + " available, "
+                                    + candiesToEvolve + " needed.");
                             return;
                         }
 
@@ -397,7 +426,9 @@ public class PokemonTab extends JPanel {
                             int newCandies = newPoke.getCandy();
                             int newCp = newPoke.getCp();
                             int newHp = newPoke.getStamina();
-                            System.out.println("Evolving " + PokeHandler.getLocalPokeName(poke) + ". Evolve result: "
+                            System.out.println("Evolving "
+                                    + PokeHandler.getLocalPokeName(poke)
+                                    + ". Evolve result: "
                                     + evolutionResultWrapper.getResult().toString());
                             if (config.getBool(ConfigKey.TRANSFER_AFTER_EVOLVE)) {
                                 ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result result = newPoke
@@ -405,12 +436,15 @@ public class PokemonTab extends JPanel {
                                 System.out.println("Transferring "
                                         + StringUtils.capitalize(newPoke.getPokemonId().toString().toLowerCase())
                                         + ", Result: " + result);
-                                System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-"
-                                        + candiesToEvolve + "]");
+                                System.out.println("Stat changes: " +
+                                        "(Candies: " + newCandies
+                                        + "[" + candies + "-" + candiesToEvolve + "]");
+
                             } else {
-                                System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-"
-                                        + candiesToEvolve + "], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp
-                                        + "[+" + (newHp - hp) + "])");
+                                System.out.println("Stat changes: "
+                                        + "(Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "],"
+                                        + " CP: " + newCp + "[+" + (newCp - cp) + "],"
+                                        + " HP: " + newHp + "[+" + (newHp - hp) + "])");
                             }
                             go.getInventories().updateInventories(true);
                             success.increment();
@@ -428,8 +462,9 @@ public class PokemonTab extends JPanel {
                         }
                     } catch (Exception e) {
                         err.increment();
-                        System.out.println("Error evolving " + PokeHandler.getLocalPokeName(poke) + "! "
-                                + Utilities.getRealExceptionMessage(e));
+                        System.out.println("Error evolving "
+                                + PokeHandler.getLocalPokeName(poke)
+                                + "! " + Utilities.getRealExceptionMessage(e));
                     }
                 });
                 try {
@@ -449,14 +484,17 @@ public class PokemonTab extends JPanel {
         ArrayList<Pokemon> selection = getSelectedPokemon();
         if (selection.size() > 0) {
             if (confirmOperation("PowerUp", selection)) {
-                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+                MutableInt err = new MutableInt(),
+                        skipped = new MutableInt(),
+                        success = new MutableInt(),
                         total = new MutableInt(1);
                 selection.forEach(poke -> {
                     try {
                         System.out.println("Doing Power Up " + total.getValue() + " of " + selection.size());
                         total.increment();
                         if (!poke.getDeployedFortId().isEmpty()) {
-                            System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp()
+                            System.out.println(PokeHandler.getLocalPokeName(poke)
+                                    + " with " + poke.getCp()
                                     + " CP is in gym, skipping.");
                             skipped.increment();
                             return;
@@ -474,8 +512,9 @@ public class PokemonTab extends JPanel {
                         if (candies < candiesToPowerUp || stardust < stardustToPowerUp) {
                             err.increment();
                             System.out.println("Error. Not enough candy/stardust to power up "
-                                    + PokeHandler.getLocalPokeName(poke) + ". Stardust: " + stardust + "/"
-                                    + stardustToPowerUp + ", Candy: " + candies + "/" + candiesToPowerUp);
+                                    + PokeHandler.getLocalPokeName(poke)
+                                    + ". Stardust: " + stardust + "/" + stardustToPowerUp
+                                    + ", Candy: " + candies + "/" + candiesToPowerUp);
                             return;
                         }
 
@@ -487,10 +526,12 @@ public class PokemonTab extends JPanel {
                             int newHp = poke.getMaxStamina();
                             System.out.println(
                                     "Powering Up " + PokeHandler.getLocalPokeName(poke) + ", Result: Success!");
-                            System.out.println("Stat changes: (Candies : " + newCandies + "[" + candies + "-"
-                                    + candiesToPowerUp + "], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp
-                                    + "[+" + (newHp - hp) + "]) Stardust used " + stardustToPowerUp + "[remaining: "
-                                    + go.getPlayerProfile().getCurrency(Currency.STARDUST) + "]");
+                            System.out.println("Stat changes: " +
+                                    "(Candies : " + newCandies + "[" + candies + "-" + candiesToPowerUp + "], "
+                                    + "CP: " + newCp + "[+" + (newCp - cp) + "], "
+                                    + "HP: " + newHp + "[+" + (newHp - hp) + "]) "
+                                    + "Stardust used " + stardustToPowerUp
+                                    + "[remaining: " + go.getPlayerProfile().getCurrency(Currency.STARDUST) + "]");
                             success.increment();
                         } else {
                             err.increment();
@@ -586,9 +627,9 @@ public class PokemonTab extends JPanel {
         }
         pt.clearSelection();
         System.out.println("Selecting Pokemon with IV less than: " + ivTransfer.getText());
-        
+
         for (int i = 0; i < pt.getRowCount(); i++) {
-            double pIv = Double.parseDouble((String) pt.getValueAt(i,3));
+            double pIv = Double.parseDouble((String) pt.getValueAt(i, 3));
             if (pIv < ivLessThan) {
                 pt.getSelectionModel().addSelectionInterval(i, i);
             }
@@ -707,7 +748,7 @@ public class PokemonTab extends JPanel {
                         poke.getPokeball().toString());
                 searchme = searchme.replaceAll("_FAST", "").replaceAll("FAMILY_", "").replaceAll("NONE", "")
                         .replaceAll("ITEM_", "").replaceAll("_", "").replaceAll(" ", "").toLowerCase();
-                
+
                 for (String s : terms) {
                     if (searchme.contains(s)) {
                         pokes.add(poke);
@@ -719,22 +760,7 @@ public class PokemonTab extends JPanel {
             });
             pt.constructNewTableModel((search.equals("") || search.equals("searchpokémon...")
                     ? go.getInventories().getPokebank().getPokemons() : pokes));
-            
-           // for (int i = 0; i < pt.getModel().getColumnCount(); i++) {
-            //    JTableColumnPacker.packColumn(pt, i, 4);
-            //}
 
-            // Custom cell renderers
-            // Magic numbers pulled from max values of their respective columns
-            // in the moveset rankings spreadsheet calculations
-            // @see
-            // https://www.reddit.com/r/TheSilphRoad/comments/4vcobt/posthotfix_pokemon_go_full_moveset_rankings/
-            //TableColumn duelAbilityCol = this.pt.getColumnModel().getColumn(24);
-            //duelAbilityCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.DUEL_ABILITY_MAX));
-            //TableColumn gymAttackCol = this.pt.getColumnModel().getColumn(25);
-            //gymAttackCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_OFFENSE_MAX));
-            //TableColumn gymDefenseCol = this.pt.getColumnModel().getColumn(26);
-            //gymDefenseCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_DEFENSE_MAX));
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -1,6 +1,5 @@
 package me.corriekay.pokegoutil.windows;
 
-import POGOProtos.Enums.PokemonFamilyIdOuterClass.PokemonFamilyId;
 import POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
 import POGOProtos.Networking.Responses.NicknamePokemonResponseOuterClass.NicknamePokemonResponse;
 import POGOProtos.Networking.Responses.ReleasePokemonResponseOuterClass;
@@ -10,26 +9,23 @@ import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.api.map.pokemon.EvolutionResult;
 import com.pokegoapi.api.player.PlayerProfile.Currency;
 import com.pokegoapi.api.pokemon.Pokemon;
-import com.pokegoapi.api.pokemon.PokemonMeta;
-import com.pokegoapi.api.pokemon.PokemonMetaRegistry;
+
 import me.corriekay.pokegoutil.utils.ConfigKey;
 import me.corriekay.pokegoutil.utils.ConfigNew;
 import me.corriekay.pokegoutil.utils.Utilities;
-import me.corriekay.pokegoutil.utils.helpers.DateHelper;
-import me.corriekay.pokegoutil.utils.helpers.JTableColumnPacker;
 import me.corriekay.pokegoutil.utils.helpers.LDocumentListener;
 import me.corriekay.pokegoutil.utils.pokemon.PokeHandler;
 import me.corriekay.pokegoutil.utils.pokemon.PokeNick;
-import me.corriekay.pokegoutil.utils.pokemon.PokemonCpUtils;
 import me.corriekay.pokegoutil.utils.pokemon.PokemonUtils;
 import me.corriekay.pokegoutil.utils.ui.GhostText;
+import me.corriekay.pokegoutil.utils.windows.PokemonTable;
+import me.corriekay.pokegoutil.utils.windows.PokemonTableModel;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
-import org.apache.commons.lang3.text.WordUtils;
 
 import javax.swing.*;
-import javax.swing.RowSorter.SortKey;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.*;
@@ -45,7 +41,7 @@ import java.util.function.BiConsumer;
 public class PokemonTab extends JPanel {
 
     private final PokemonGo go;
-    private final PokemonTable pt = new PokemonTable();
+    private final PokemonTable pt;
     private final JTextField searchBar = new JTextField("");
     private final JTextField ivTransfer = new JTextField("", 20);
 
@@ -54,6 +50,7 @@ public class PokemonTab extends JPanel {
     public PokemonTab(PokemonGo go) {
         setLayout(new BorderLayout());
         this.go = go;
+        pt = new PokemonTable(go);
         JPanel topPanel = new JPanel(new GridBagLayout());
         JButton refreshPkmn, renameSelected, transferSelected, evolveSelected, powerUpSelected, toggleFavorite;
         refreshPkmn = new JButton("Refresh List");
@@ -136,15 +133,14 @@ public class PokemonTab extends JPanel {
 
                     @Override
                     public void keyTyped(KeyEvent e) {
-                        //nothing here
+                        // nothing here
                     }
 
                     @Override
                     public void keyReleased(KeyEvent e) {
-                        //nothing here
+                        // nothing here
                     }
-                }
-        );
+                });
 
         topPanel.add(ivTransfer, gbc);
 
@@ -165,7 +161,7 @@ public class PokemonTab extends JPanel {
         topPanel.add(searchBar, gbc);
 
         // pokemon name language drop down
-        String[] locales = {"en", "de", "fr", "ru", "zh_CN", "zh_HK", "ja"};
+        String[] locales = { "en", "de", "fr", "ru", "zh_CN", "zh_HK", "ja" };
         JComboBox<String> pokelang = new JComboBox<>(locales);
         String locale = config.getString(ConfigKey.LANGUAGE);
         pokelang.setSelectedItem(locale);
@@ -188,7 +184,7 @@ public class PokemonTab extends JPanel {
         }
 
         // Font size dropdown
-        String[] sizes = {"11", "12", "13", "14", "15", "16", "17", "18"};
+        String[] sizes = { "11", "12", "13", "14", "15", "16", "17", "18" };
         JComboBox<String> fontSize = new JComboBox<>(sizes);
         fontSize.setSelectedItem(String.valueOf(size));
         fontSize.addActionListener(e -> new SwingWorker<Void, Void>() {
@@ -243,10 +239,12 @@ public class PokemonTab extends JPanel {
 
     private void renameSelected() {
         ArrayList<Pokemon> selection = getSelectedPokemon();
-        if (selection.size() == 0) return;
+        if (selection.size() == 0)
+            return;
         String renamePattern = inputOperation("Rename", selection);
 
-        MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(), total = new MutableInt(1);
+        MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+                total = new MutableInt(1);
         PokeHandler handler = new PokeHandler(selection);
 
         BiConsumer<NicknamePokemonResponse.Result, Pokemon> perPokeCallback = (renameResult, pokemon) -> {
@@ -259,7 +257,8 @@ public class PokemonTab extends JPanel {
             boolean isSkipped = (pokeNick.equals(pokemon.getNickname())
                     && renameResult.getNumber() == NicknamePokemonResponse.Result.UNSET_VALUE);
             if (isSkipped) {
-                System.out.println("Skipped renaming " + PokeHandler.getLocalPokeName(pokemon) + ", already named " + pokemon.getNickname());
+                System.out.println("Skipped renaming " + PokeHandler.getLocalPokeName(pokemon) + ", already named "
+                        + pokemon.getNickname());
                 skipped.increment();
                 return;
             }
@@ -267,12 +266,17 @@ public class PokemonTab extends JPanel {
             if (renameResult.getNumber() == NicknamePokemonResponse.Result.SUCCESS_VALUE) {
                 success.increment();
                 if (pokeNick.isTooLong()) {
-                    System.out.println("WARNING: Nickname \"" + pokeNick.fullNickname + "\" is too long. Get's cut to: " + pokeNick.toString());
+                    System.out.println("WARNING: Nickname \"" + pokeNick.fullNickname + "\" is too long. Get's cut to: "
+                            + pokeNick.toString());
                 }
-                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " from \"" + pokemon.getNickname() + "\" to \"" + PokeHandler.generatePokemonNickname(renamePattern, pokemon) + "\", Result: Success!");
+                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " from \""
+                        + pokemon.getNickname() + "\" to \""
+                        + PokeHandler.generatePokemonNickname(renamePattern, pokemon) + "\", Result: Success!");
             } else {
                 err.increment();
-                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " failed! Code: " + renameResult.toString() + "; Nick: " + PokeHandler.generatePokemonNickname(renamePattern, pokemon));
+                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " failed! Code: "
+                        + renameResult.toString() + "; Nick: "
+                        + PokeHandler.generatePokemonNickname(renamePattern, pokemon));
             }
 
             // If not last element and API was queried, sleep until the next one
@@ -296,34 +300,41 @@ public class PokemonTab extends JPanel {
 
     private void transferSelected() {
         ArrayList<Pokemon> selection = getSelectedPokemon();
-        if (selection.size() == 0) return;
+        if (selection.size() == 0)
+            return;
         if (confirmOperation("Transfer", selection)) {
-            MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(), total = new MutableInt(1);
+            MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+                    total = new MutableInt(1);
             selection.forEach(poke -> {
                 System.out.println("Doing Transfer " + total.getValue() + " of " + selection.size());
                 total.increment();
                 if (poke.isFavorite()) {
-                    System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp() + " CP is favorite, skipping.");
+                    System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp()
+                            + " CP is favorite, skipping.");
                     skipped.increment();
                     return;
                 }
                 if (!poke.getDeployedFortId().isEmpty()) {
-                    System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp() + " CP is in gym, skipping.");
+                    System.out.println(
+                            PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp() + " CP is in gym, skipping.");
                     skipped.increment();
                     return;
                 }
 
                 try {
                     int candies = poke.getCandy();
-                    ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result transferResult = poke.transferPokemon();
+                    ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result transferResult = poke
+                            .transferPokemon();
 
                     if (transferResult == ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result.SUCCESS) {
                         int newCandies = poke.getCandy();
                         System.out.println("Transferring " + PokeHandler.getLocalPokeName(poke) + ", Result: Success!");
-                        System.out.println("Stat changes: (Candies : " + newCandies + "[+" + (newCandies - candies) + "])");
+                        System.out.println(
+                                "Stat changes: (Candies : " + newCandies + "[+" + (newCandies - candies) + "])");
                         success.increment();
                     } else {
-                        System.out.println("Error transferring " + PokeHandler.getLocalPokeName(poke) + ", result: " + transferResult.toString());
+                        System.out.println("Error transferring " + PokeHandler.getLocalPokeName(poke) + ", result: "
+                                + transferResult.toString());
                         err.increment();
                     }
 
@@ -335,7 +346,8 @@ public class PokemonTab extends JPanel {
                     }
                 } catch (Exception e) {
                     err.increment();
-                    System.out.println("Error transferring " + PokeHandler.getLocalPokeName(poke) + "! " + Utilities.getRealExceptionMessage(e));
+                    System.out.println("Error transferring " + PokeHandler.getLocalPokeName(poke) + "! "
+                            + Utilities.getRealExceptionMessage(e));
                 }
             });
             try {
@@ -352,12 +364,14 @@ public class PokemonTab extends JPanel {
         ArrayList<Pokemon> selection = getSelectedPokemon();
         if (selection.size() > 0) {
             if (confirmOperation("Evolve", selection)) {
-                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(), total = new MutableInt(1);
+                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+                        total = new MutableInt(1);
                 selection.forEach(poke -> {
                     System.out.println("Doing Evolve " + total.getValue() + " of " + selection.size());
                     total.increment();
                     if (!poke.getDeployedFortId().isEmpty()) {
-                        System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp() + " CP is in gym, skipping.");
+                        System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp()
+                                + " CP is in gym, skipping.");
                         skipped.increment();
                         return;
                     }
@@ -368,10 +382,12 @@ public class PokemonTab extends JPanel {
                         int cp = poke.getCp();
                         int hp = poke.getMaxStamina();
 
-                        // Check if user has enough candy, otherwise we don't need to call server
+                        // Check if user has enough candy, otherwise we don't
+                        // need to call server
                         if (candies < candiesToEvolve) {
                             err.increment();
-                            System.out.println("Error. Not enough candy to evolve " + PokeHandler.getLocalPokeName(poke) + ". " + candies + " available, " + candiesToEvolve + " needed.");
+                            System.out.println("Error. Not enough candy to evolve " + PokeHandler.getLocalPokeName(poke)
+                                    + ". " + candies + " available, " + candiesToEvolve + " needed.");
                             return;
                         }
 
@@ -381,19 +397,27 @@ public class PokemonTab extends JPanel {
                             int newCandies = newPoke.getCandy();
                             int newCp = newPoke.getCp();
                             int newHp = newPoke.getStamina();
-                            System.out.println("Evolving " + PokeHandler.getLocalPokeName(poke) + ". Evolve result: " + evolutionResultWrapper.getResult().toString());
+                            System.out.println("Evolving " + PokeHandler.getLocalPokeName(poke) + ". Evolve result: "
+                                    + evolutionResultWrapper.getResult().toString());
                             if (config.getBool(ConfigKey.TRANSFER_AFTER_EVOLVE)) {
-                                ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result result = newPoke.transferPokemon();
-                                System.out.println("Transferring " + StringUtils.capitalize(newPoke.getPokemonId().toString().toLowerCase()) + ", Result: " + result);
-                                System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "]");
+                                ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result result = newPoke
+                                        .transferPokemon();
+                                System.out.println("Transferring "
+                                        + StringUtils.capitalize(newPoke.getPokemonId().toString().toLowerCase())
+                                        + ", Result: " + result);
+                                System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-"
+                                        + candiesToEvolve + "]");
                             } else {
-                                System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp + "[+" + (newHp - hp) + "])");
+                                System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-"
+                                        + candiesToEvolve + "], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp
+                                        + "[+" + (newHp - hp) + "])");
                             }
                             go.getInventories().updateInventories(true);
                             success.increment();
                         } else {
                             err.increment();
-                            System.out.println("Error evolving " + PokeHandler.getLocalPokeName(poke) + ", result: " + evolutionResultWrapper.getResult().toString());
+                            System.out.println("Error evolving " + PokeHandler.getLocalPokeName(poke) + ", result: "
+                                    + evolutionResultWrapper.getResult().toString());
                         }
 
                         // If not last element, sleep until the next one
@@ -404,7 +428,8 @@ public class PokemonTab extends JPanel {
                         }
                     } catch (Exception e) {
                         err.increment();
-                        System.out.println("Error evolving " + PokeHandler.getLocalPokeName(poke) + "! " + Utilities.getRealExceptionMessage(e));
+                        System.out.println("Error evolving " + PokeHandler.getLocalPokeName(poke) + "! "
+                                + Utilities.getRealExceptionMessage(e));
                     }
                 });
                 try {
@@ -424,13 +449,15 @@ public class PokemonTab extends JPanel {
         ArrayList<Pokemon> selection = getSelectedPokemon();
         if (selection.size() > 0) {
             if (confirmOperation("PowerUp", selection)) {
-                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(), total = new MutableInt(1);
+                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+                        total = new MutableInt(1);
                 selection.forEach(poke -> {
                     try {
                         System.out.println("Doing Power Up " + total.getValue() + " of " + selection.size());
                         total.increment();
                         if (!poke.getDeployedFortId().isEmpty()) {
-                            System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp() + " CP is in gym, skipping.");
+                            System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp()
+                                    + " CP is in gym, skipping.");
                             skipped.increment();
                             return;
                         }
@@ -442,10 +469,13 @@ public class PokemonTab extends JPanel {
                         int stardustToPowerUp = poke.getStardustCostsForPowerup();
                         int candiesToPowerUp = poke.getCandyCostsForPowerup();
 
-                        // Check if user has enough candy and stardust, otherwise we don't need to call server
+                        // Check if user has enough candy and stardust,
+                        // otherwise we don't need to call server
                         if (candies < candiesToPowerUp || stardust < stardustToPowerUp) {
                             err.increment();
-                            System.out.println("Error. Not enough candy/stardust to power up " + PokeHandler.getLocalPokeName(poke) + ". Stardust: " + stardust + "/" + stardustToPowerUp + ", Candy: " + candies + "/" + candiesToPowerUp);
+                            System.out.println("Error. Not enough candy/stardust to power up "
+                                    + PokeHandler.getLocalPokeName(poke) + ". Stardust: " + stardust + "/"
+                                    + stardustToPowerUp + ", Candy: " + candies + "/" + candiesToPowerUp);
                             return;
                         }
 
@@ -455,12 +485,17 @@ public class PokemonTab extends JPanel {
                             int newCandies = poke.getCandy();
                             int newCp = poke.getCp();
                             int newHp = poke.getMaxStamina();
-                            System.out.println("Powering Up " + PokeHandler.getLocalPokeName(poke) + ", Result: Success!");
-                            System.out.println("Stat changes: (Candies : " + newCandies + "[" + candies + "-" + candiesToPowerUp + "], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp + "[+" + (newHp - hp) + "]) Stardust used " + stardustToPowerUp + "[remaining: " + go.getPlayerProfile().getCurrency(Currency.STARDUST) + "]");
+                            System.out.println(
+                                    "Powering Up " + PokeHandler.getLocalPokeName(poke) + ", Result: Success!");
+                            System.out.println("Stat changes: (Candies : " + newCandies + "[" + candies + "-"
+                                    + candiesToPowerUp + "], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp
+                                    + "[+" + (newHp - hp) + "]) Stardust used " + stardustToPowerUp + "[remaining: "
+                                    + go.getPlayerProfile().getCurrency(Currency.STARDUST) + "]");
                             success.increment();
                         } else {
                             err.increment();
-                            System.out.println("Error powering up " + PokeHandler.getLocalPokeName(poke) + ", result: " + upgradeResult.toString());
+                            System.out.println("Error powering up " + PokeHandler.getLocalPokeName(poke) + ", result: "
+                                    + upgradeResult.toString());
                         }
 
                         // If not last element, sleep until the next one
@@ -471,7 +506,8 @@ public class PokemonTab extends JPanel {
                         }
                     } catch (Exception e) {
                         err.increment();
-                        System.out.println("Error powering up " + PokeHandler.getLocalPokeName(poke) + "! " + Utilities.getRealExceptionMessage(e));
+                        System.out.println("Error powering up " + PokeHandler.getLocalPokeName(poke) + "! "
+                                + Utilities.getRealExceptionMessage(e));
                     }
                 });
                 try {
@@ -486,26 +522,31 @@ public class PokemonTab extends JPanel {
         }
     }
 
-    //feature added by Ben Kauffman
+    // feature added by Ben Kauffman
     private void toggleFavorite() {
         ArrayList<Pokemon> selection = getSelectedPokemon();
         if (selection.size() > 0) {
             if (confirmOperation("Toggle Favorite", selection)) {
-                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(), total = new MutableInt(1);
+                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+                        total = new MutableInt(1);
                 selection.forEach(poke -> {
                     try {
                         System.out.println("Toggling favorite " + total.getValue() + " of " + selection.size());
                         total.increment();
-                        SetFavoritePokemonResponseOuterClass.SetFavoritePokemonResponse.Result favoriteResult = poke.setFavoritePokemon(!poke.isFavorite());
-                        System.out.println("Attempting to set favorite for " + PokeHandler.getLocalPokeName(poke) + " to " + !poke.isFavorite() + "...");
+                        SetFavoritePokemonResponseOuterClass.SetFavoritePokemonResponse.Result favoriteResult = poke
+                                .setFavoritePokemon(!poke.isFavorite());
+                        System.out.println("Attempting to set favorite for " + PokeHandler.getLocalPokeName(poke)
+                                + " to " + !poke.isFavorite() + "...");
                         go.getPlayerProfile().updateProfile();
 
                         if (favoriteResult == SetFavoritePokemonResponseOuterClass.SetFavoritePokemonResponse.Result.SUCCESS) {
-                            System.out.println("Favorite for " + PokeHandler.getLocalPokeName(poke) + " set to " + !poke.isFavorite() + ", Result: Success!");
+                            System.out.println("Favorite for " + PokeHandler.getLocalPokeName(poke) + " set to "
+                                    + !poke.isFavorite() + ", Result: Success!");
                             success.increment();
                         } else {
                             err.increment();
-                            System.out.println("Error toggling favorite for " + PokeHandler.getLocalPokeName(poke) + ", result: " + favoriteResult.toString());
+                            System.out.println("Error toggling favorite for " + PokeHandler.getLocalPokeName(poke)
+                                    + ", result: " + favoriteResult.toString());
                         }
 
                         // If not last element, sleep until the next one
@@ -516,7 +557,8 @@ public class PokemonTab extends JPanel {
                         }
                     } catch (Exception e) {
                         err.increment();
-                        System.out.println("Error toggling favorite for " + PokeHandler.getLocalPokeName(poke) + "! " + Utilities.getRealExceptionMessage(e));
+                        System.out.println("Error toggling favorite for " + PokeHandler.getLocalPokeName(poke) + "! "
+                                + Utilities.getRealExceptionMessage(e));
                     }
                 });
                 try {
@@ -525,7 +567,8 @@ public class PokemonTab extends JPanel {
                     e.printStackTrace();
                 }
                 SwingUtilities.invokeLater(this::refreshPkmn);
-                showFinishedText("Pokémon batch \"toggle favorite\" complete!", selection.size(), success, skipped, err);
+                showFinishedText("Pokémon batch \"toggle favorite\" complete!", selection.size(), success, skipped,
+                        err);
             }
         }
     }
@@ -543,8 +586,9 @@ public class PokemonTab extends JPanel {
         }
         pt.clearSelection();
         System.out.println("Selecting Pokemon with IV less than: " + ivTransfer.getText());
+        
         for (int i = 0; i < pt.getRowCount(); i++) {
-            double pIv = (double) pt.getValueAt(i, 3);
+            double pIv = Double.parseDouble((String) pt.getValueAt(i,3));
             if (pIv < ivLessThan) {
                 pt.getSelectionModel().addSelectionInterval(i, i);
             }
@@ -555,12 +599,13 @@ public class PokemonTab extends JPanel {
         JPanel panel = _buildPanelForOperation(operation, pokes);
         String message = "";
         switch (operation) {
-            case "Rename":
-                message = "You want to rename " + pokes.size() + " Pokémon.\nYou can rename with normal text and patterns, or both combined. Patterns are going to be replaced with the Pokémons values.\nExisting patterns:\n";
-                for (PokeHandler.ReplacePattern pattern : PokeHandler.ReplacePattern.values()) {
-                    message += "%" + pattern.name().toLowerCase() + "% -> " + pattern.toString() + "\n";
-                }
-                message += "\n";
+        case "Rename":
+            message = "You want to rename " + pokes.size()
+                    + " Pokémon.\nYou can rename with normal text and patterns, or both combined. Patterns are going to be replaced with the Pokémons values.\nExisting patterns:\n";
+            for (PokeHandler.ReplacePattern pattern : PokeHandler.ReplacePattern.values()) {
+                message += "%" + pattern.name().toLowerCase() + "% -> " + pattern.toString() + "\n";
+            }
+            message += "\n";
         }
 
         String input = JOptionPane.showInputDialog(panel, message, operation, JOptionPane.PLAIN_MESSAGE);
@@ -590,7 +635,8 @@ public class PokemonTab extends JPanel {
         // Auto-height? Resizable? Haha. Funny joke.
         // I hate swing. But we need to get around here some way.
         // So lets get dirty.
-        // We take 20 px for each row, 5 px buffer, and cap that at may 400 pixel.
+        // We take 20 px for each row, 5 px buffer, and cap that at may 400
+        // pixel.
         int height = Math.min(400, pokes.size() * 20 + 5);
         panel.setPreferredSize(new Dimension(500, height));
 
@@ -598,19 +644,19 @@ public class PokemonTab extends JPanel {
             String str = PokeHandler.getLocalPokeName(p) + " - CP: " + p.getCp() + ", IV: "
                     + Utilities.percentageWithTwoCharacters(PokemonUtils.ivRating(p)) + "%";
             switch (operation) {
-                case "Evolve":
-                    str += " Cost: " + p.getCandiesToEvolve();
-                    str += p.getCandiesToEvolve() > 1 ? " Candies" : " Candy";
-                    break;
-                case "PowerUp":
-                    str += " Cost: " + p.getCandyCostsForPowerup();
-                    str += p.getCandyCostsForPowerup() > 1 ? " Candies" : " Candy";
-                    str += " " + p.getStardustCostsForPowerup() + " Stardust";
-                    break;
-                case "Rename":
-                    break;
-                case "Transfer":
-                    break;
+            case "Evolve":
+                str += " Cost: " + p.getCandiesToEvolve();
+                str += p.getCandiesToEvolve() > 1 ? " Candies" : " Candy";
+                break;
+            case "PowerUp":
+                str += " Cost: " + p.getCandyCostsForPowerup();
+                str += p.getCandyCostsForPowerup() > 1 ? " Candies" : " Candy";
+                str += " " + p.getStardustCostsForPowerup() + " Stardust";
+                break;
+            case "Rename":
+                break;
+            case "Transfer":
+                break;
             }
             innerPanel.add(new JLabel(str));
         });
@@ -632,7 +678,8 @@ public class PokemonTab extends JPanel {
 
     public void refreshList() {
         List<Pokemon> pokes = new ArrayList<>();
-        String search = searchBar.getText().replaceAll(" ", "").replaceAll("_", "").replaceAll("snek", "ekans").toLowerCase();
+        String search = searchBar.getText().replaceAll(" ", "").replaceAll("_", "").replaceAll("snek", "ekans")
+                .toLowerCase();
         String[] terms = search.split(";");
         try {
             go.getInventories().getPokebank().getPokemons().forEach(poke -> {
@@ -641,57 +688,53 @@ public class PokemonTab extends JPanel {
                 if (useFamilyName) {
                     // Try translating family name
                     try {
-                        PokemonId familyPokemonId = PokemonId.valueOf(poke.getPokemonFamily().toString().replaceAll("FAMILY_", ""));
+                        PokemonId familyPokemonId = PokemonId
+                                .valueOf(poke.getPokemonFamily().toString().replaceAll("FAMILY_", ""));
                         familyName = PokeHandler.getLocalPokeName(familyPokemonId.getNumber());
                     } catch (IllegalArgumentException e) {
                         familyName = poke.getPokemonFamily().toString();
                     }
                 }
 
-                String searchme = PokeHandler.getLocalPokeName(poke)
-                        + ((useFamilyName) ? familyName : "")
-                        + poke.getNickname()
-                        + poke.getMeta().getType1() + poke.getMeta().getType2() + poke.getMove1() + poke.getMove2()
-                        + poke.getPokeball();
-                searchme = searchme.replaceAll("_FAST", "").replaceAll("FAMILY_", "").replaceAll("NONE", "").replaceAll("ITEM_", "").replaceAll("_", "").replaceAll(" ", "").toLowerCase();
+                String searchme = Utilities.concatString(',',
+                        PokeHandler.getLocalPokeName(poke).toString(),
+                        ((useFamilyName) ? familyName : ""),
+                        poke.getNickname().toString(),
+                        poke.getMeta().getType1().toString(),
+                        poke.getMeta().getType2().toString(),
+                        poke.getMove1().toString(),
+                        poke.getMove2().toString(),
+                        poke.getPokeball().toString());
+                searchme = searchme.replaceAll("_FAST", "").replaceAll("FAMILY_", "").replaceAll("NONE", "")
+                        .replaceAll("ITEM_", "").replaceAll("_", "").replaceAll(" ", "").toLowerCase();
+                
                 for (String s : terms) {
                     if (searchme.contains(s)) {
                         pokes.add(poke);
-                        // Break, so that a Pokémon isn't added twice even if it matches more than one criteria
+                        // Break, so that a Pokémon isn't added twice even if it
+                        // matches more than one criteria
                         break;
                     }
                 }
             });
-            pt.constructNewTableModel(go, (search.equals("") || search.equals("searchpokémon...")
+            pt.constructNewTableModel((search.equals("") || search.equals("searchpokémon...")
                     ? go.getInventories().getPokebank().getPokemons() : pokes));
-            for (int i = 0; i < pt.getModel().getColumnCount(); i++) {
-                JTableColumnPacker.packColumn(pt, i, 4);
-            }
+            
+           // for (int i = 0; i < pt.getModel().getColumnCount(); i++) {
+            //    JTableColumnPacker.packColumn(pt, i, 4);
+            //}
 
             // Custom cell renderers
-            // Magic numbers pulled from max values of their respective columns in the moveset rankings spreadsheet calculations
-            // @see https://www.reddit.com/r/TheSilphRoad/comments/4vcobt/posthotfix_pokemon_go_full_moveset_rankings/
-            TableColumn duelAbilityCol = this.pt.getColumnModel().getColumn(24);
-            duelAbilityCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.DUEL_ABILITY_MAX));
-            TableColumn gymAttackCol = this.pt.getColumnModel().getColumn(25);
-            gymAttackCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_OFFENSE_MAX));
-            TableColumn gymDefenseCol = this.pt.getColumnModel().getColumn(26);
-            gymDefenseCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_DEFENSE_MAX));
-            TableColumn duelAbilityIVCol = this.pt.getColumnModel().getColumn(31);
-            duelAbilityIVCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.DUEL_ABILITY_IV_MAX));
-            TableColumn gymAttackIVCol = this.pt.getColumnModel().getColumn(32);
-            gymAttackIVCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_OFFENSE_IV_MAX));
-            TableColumn gymDefenseIVCol = this.pt.getColumnModel().getColumn(33);
-            gymDefenseIVCol.setCellRenderer(new MoveSetRankingRenderer(PokemonUtils.GYM_DEFENSE_IV_MAX));
         } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
     /**
-     * Provide custom formatting for the moveset ranking columns while allowing sorting on original values
+     * Provide custom formatting for the moveset ranking columns while allowing
+     * sorting on original values
      */
-    private static class MoveSetRankingRenderer extends JLabel implements TableCellRenderer {
+    public static class MoveSetRankingRenderer extends JLabel implements TableCellRenderer {
 
         private final long scale;
 
@@ -701,7 +744,7 @@ public class PokemonTab extends JPanel {
 
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
-                                                       boolean hasFocus, int rowIndex, int vColIndex) {
+                boolean hasFocus, int rowIndex, int vColIndex) {
             setText(Utilities.percentageWithTwoCharacters(Double.parseDouble(value.toString()), this.scale));
             setToolTipText(NumberFormat.getInstance().format(value));
             setOpaque(true);
@@ -717,476 +760,6 @@ public class PokemonTab extends JPanel {
         } else {
             tcr.setBackground(table.getBackground());
             tcr.setForeground(table.getForeground());
-        }
-    }
-
-    private static class PokemonTable extends JTable {
-
-        /**
-         * data types:
-         * 0 String - Nickname
-         * 1 Integer - Pokemon Number
-         * 2 String - Type / Pokemon
-         * 3 String(Percentage) - IV Rating
-         * 4 Double - Level
-         * 5 Integer - Attack
-         * 6 Integer - Defense
-         * 7 Integer - Stamina
-         * 8 String - Type 1
-         * 9 String - Type 2
-         * 10 String - Move 1
-         * 11 String - Move 2
-         * 12 Integer - CP
-         * 13 Integer - HP
-         * 14 Integer - Max CP (Current)
-         * 15 Integer - Max CP
-         * 16 Integer - Max Evolved CP (Current)
-         * 17 Integer - Max Evolved CP
-         * 18 Integer - Candies of type
-         * 19 String(Nullable Int) - Candies to Evolve
-         * 20 Integer - Star Dust to level
-         * 21 String - Pokeball Type
-         * 22 String(Date) - Caught at
-         * 23 Boolean - Favorite
-         * 24 Long - duelAbility
-         * 25 Integer - gymOffense
-         * 26 Integer - gymDefense
-         * 27 String(Percentage) - Move 1 Rating
-         * 28 String(Percentage) - Move 2 Rating
-         * 29 String(Nullable Int) - CP Evolved
-         * 30 String(Nullable Int) - Evolvable
-         * 31 Long - duelAbility IV
-         * 32 Double - gymOffense IV
-         * 33 Long - gymDefense IV
-         */
-        ConfigNew config = ConfigNew.getConfig();
-
-        int sortColIndex1, sortColIndex2;
-        SortOrder sortOrder1, sortOrder2;
-
-        private PokemonTable() {
-            setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
-            setAutoResizeMode(AUTO_RESIZE_OFF);
-
-            // Load sort configs
-            sortColIndex1 = config.getInt(ConfigKey.SORT_COLINDEX_1);
-            sortColIndex2 = config.getInt(ConfigKey.SORT_COLINDEX_2);
-            try {
-                sortOrder1 = SortOrder.valueOf(config.getString(ConfigKey.SORT_ORDER_1));
-                sortOrder2 = SortOrder.valueOf(config.getString(ConfigKey.SORT_ORDER_2));
-            } catch (IllegalArgumentException e) {
-                e.printStackTrace();
-                sortOrder1 = SortOrder.ASCENDING;
-                sortOrder2 = SortOrder.ASCENDING;
-            }
-        }
-
-        private void constructNewTableModel(PokemonGo go, List<Pokemon> pokes) {
-            PokemonTableModel ptm = new PokemonTableModel(go, pokes, this);
-            setModel(ptm);
-            TableRowSorter<TableModel> trs = new TableRowSorter<>(getModel());
-            Comparator<Integer> c = Integer::compareTo;
-            Comparator<Double> cDouble = Double::compareTo;
-            Comparator<String> cDate = (date1, date2) -> DateHelper.fromString(date1).compareTo(DateHelper.fromString(date2));
-            Comparator<String> cNullableInt = (s1, s2) -> {
-                if ("-".equals(s1))
-                    s1 = "0";
-                if ("-".equals(s2))
-                    s2 = "0";
-                return Integer.parseInt(s1) - Integer.parseInt(s2);
-            };
-            Comparator<Long> cLong = Long::compareTo;
-            Comparator<String> cPercentageWithTwoCharacters = (s1, s2) -> {
-                int i1 = ("XX".equals(s1)) ? 100 : Integer.parseInt(s1);
-                int i2 = ("XX".equals(s2)) ? 100 : Integer.parseInt(s2);
-                return i1 - i2;
-            };
-            trs.setComparator(0, c);
-            trs.setComparator(3, cPercentageWithTwoCharacters);
-            trs.setComparator(4, cDouble);
-            trs.setComparator(5, c);
-            trs.setComparator(6, c);
-            trs.setComparator(7, c);
-            trs.setComparator(12, c);
-            trs.setComparator(13, c);
-            trs.setComparator(14, c);
-            trs.setComparator(15, c);
-            trs.setComparator(16, c);
-            trs.setComparator(17, c);
-            trs.setComparator(18, c);
-            trs.setComparator(19, cNullableInt);
-            trs.setComparator(20, c);
-            trs.setComparator(22, cDate);
-            trs.setComparator(24, cLong);
-            trs.setComparator(25, cDouble);
-            trs.setComparator(26, cLong);
-            trs.setComparator(27, cPercentageWithTwoCharacters);
-            trs.setComparator(28, cPercentageWithTwoCharacters);
-            trs.setComparator(29, cNullableInt);
-            trs.setComparator(30, cNullableInt);
-            trs.setComparator(31, cLong);
-            trs.setComparator(32, cDouble);
-            trs.setComparator(33, cLong);
-            setRowSorter(trs);
-            List<SortKey> sortKeys = new ArrayList<>();
-            sortKeys.add(new SortKey(sortColIndex1, sortOrder1));
-            sortKeys.add(new SortKey(sortColIndex2, sortOrder2));
-            trs.setSortKeys(sortKeys);
-
-            // Add listener to save those sorting values
-            trs.addRowSorterListener(
-                    e -> {
-                        RowSorter sorter = e.getSource();
-                        if (sorter != null) {
-                            List<SortKey> keys = sorter.getSortKeys();
-                            if (keys.size() > 0) {
-                                SortKey prim = keys.get(0);
-                                sortOrder1 = prim.getSortOrder();
-                                config.setString(ConfigKey.SORT_ORDER_1, sortOrder1.toString());
-                                sortColIndex1 = prim.getColumn();
-                                config.setInt(ConfigKey.SORT_COLINDEX_1, sortColIndex1);
-                            }
-                            if (keys.size() > 1) {
-                                SortKey sec = keys.get(1);
-                                sortOrder2 = sec.getSortOrder();
-                                config.setString(ConfigKey.SORT_ORDER_2, sortOrder2.toString());
-                                sortColIndex2 = sec.getColumn();
-                                config.setInt(ConfigKey.SORT_COLINDEX_2, sortColIndex2);
-                            }
-                        }
-                    });
-        }
-    }
-
-    private static class PokemonTableModel extends AbstractTableModel {
-
-        PokemonTable pt;
-
-        private final ArrayList<Pokemon> pokeCol = new ArrayList<>();
-        private final ArrayList<Integer> numIdCol = new ArrayList<>();//0
-        private final ArrayList<String> nickCol = new ArrayList<>(),//1
-                speciesCol = new ArrayList<>(),//2
-                ivCol = new ArrayList<>();//3
-        private final ArrayList<Double> levelCol = new ArrayList<>();//4
-        private final ArrayList<Integer> atkCol = new ArrayList<>(),//5
-                defCol = new ArrayList<>(),//6
-                stamCol = new ArrayList<>();//7
-        private final ArrayList<String> type1Col = new ArrayList<>(),//8
-                type2Col = new ArrayList<>(),//9
-                move1Col = new ArrayList<>(),//10
-                move2Col = new ArrayList<>();//11
-        private final ArrayList<Integer> cpCol = new ArrayList<>(),//12
-                hpCol = new ArrayList<>(),//13
-                maxCpCurrentCol = new ArrayList<>(),//14
-                maxCpCol = new ArrayList<>(),//15
-                maxEvolvedCpCurrentCol = new ArrayList<>(),//16
-                maxEvolvedCpCol = new ArrayList<>(),//17
-                candiesCol = new ArrayList<>();//18
-        private final ArrayList<String> candies2EvlvCol = new ArrayList<>();//19
-        private final ArrayList<Integer> dustToLevelCol = new ArrayList<>();//20
-        private final ArrayList<String> pokeballCol = new ArrayList<>(),//21
-                caughtCol = new ArrayList<>(),//22
-                favCol = new ArrayList<>();//23
-        private final ArrayList<Long> duelAbilityCol = new ArrayList<>();//24
-        private final ArrayList<Double> gymOffenseCol = new ArrayList<>();//25
-        private final ArrayList<Long> gymDefenseCol = new ArrayList<>();//26
-        private final ArrayList<String> move1RatingCol = new ArrayList<>(),//27
-                move2RatingCol = new ArrayList<>();//28
-        private final ArrayList<String> cpEvolvedCol = new ArrayList<>(),//29
-                evolvableCol = new ArrayList<>();//30
-        private final ArrayList<Long> duelAbilityIVCol = new ArrayList<>();//31
-        private final ArrayList<Double> gymOffenseIVCol = new ArrayList<>();//32
-        private final ArrayList<Long> gymDefenseIVCol = new ArrayList<>();//33
-
-        @Deprecated
-        private PokemonTableModel(PokemonGo go, List<Pokemon> pokes, PokemonTable pt) {
-            this.pt = pt;
-            MutableInt i = new MutableInt();
-            pokes.forEach(p -> {
-                pokeCol.add(i.getValue(), p);
-                numIdCol.add(i.getValue(), p.getMeta().getNumber());
-                nickCol.add(i.getValue(), p.getNickname());
-                speciesCol.add(i.getValue(),
-                        PokeHandler.getLocalPokeName(p));
-                levelCol.add(i.getValue(), (double) p.getLevel());
-                ivCol.add(i.getValue(), Utilities.percentageWithTwoCharacters(PokemonUtils.ivRating(p)));
-                cpCol.add(i.getValue(), p.getCp());
-                atkCol.add(i.getValue(), p.getIndividualAttack());
-                defCol.add(i.getValue(), p.getIndividualDefense());
-                stamCol.add(i.getValue(), p.getIndividualStamina());
-                type1Col.add(i.getValue(), StringUtils.capitalize(p.getMeta().getType1().toString().toLowerCase()));
-                type2Col.add(i.getValue(), StringUtils.capitalize(p.getMeta().getType2().toString().toLowerCase().replaceAll("none", "")));
-
-                Double dps1 = PokemonUtils.dpsForMove(p, true);
-                Double dps2 = PokemonUtils.dpsForMove(p, false);
-
-                move1Col.add(i.getValue(), WordUtils.capitalize(p.getMove1().toString().toLowerCase().replaceAll("_fast", "").replaceAll("_", " ")) + " (" + String.format("%.2f", dps1) + "dps)");
-                move2Col.add(i.getValue(), WordUtils.capitalize(p.getMove2().toString().toLowerCase().replaceAll("_", " ")) + " (" + String.format("%.2f", dps2) + "dps)");
-                hpCol.add(i.getValue(), p.getMaxStamina());
-
-                int trainerLevel = 1;
-                try {
-                    trainerLevel = go.getPlayerProfile().getStats().getLevel();
-                } catch (Exception e1) {
-                    e1.printStackTrace();
-                }
-
-                // Max CP calculation for current Pokemon
-                PokemonMeta pokemonMeta = PokemonMetaRegistry.getMeta(p.getPokemonId());
-                int maxCpCurrent = 0, maxCp = 0;
-                if (pokemonMeta == null) {
-                    System.out.println("Error: Cannot find meta data for " + p.getPokemonId().name());
-                } else {
-                    int attack = p.getIndividualAttack() + pokemonMeta.getBaseAttack();
-                    int defense = p.getIndividualDefense() + pokemonMeta.getBaseDefense();
-                    int stamina = p.getIndividualStamina() + pokemonMeta.getBaseStamina();
-                    maxCpCurrent = PokemonCpUtils.getMaxCpForTrainerLevel(attack, defense, stamina, trainerLevel);
-                    maxCp = PokemonCpUtils.getMaxCp(attack, defense, stamina);
-                    maxCpCurrentCol.add(i.getValue(), maxCpCurrent);
-                    maxCpCol.add(i.getValue(), maxCp);
-                }
-
-                // Max CP calculation for highest evolution of current Pokemon
-                PokemonFamilyId familyId = p.getPokemonFamily();
-                PokemonId highestFamilyId = PokemonMetaRegistry.getHightestForFamily(familyId);
-
-                // Eeveelutions exception handling
-                if (familyId.getNumber() == PokemonFamilyId.FAMILY_EEVEE.getNumber()) {
-                    if (p.getPokemonId().getNumber() == PokemonId.EEVEE.getNumber()) {
-                        PokemonMeta vap = PokemonMetaRegistry.getMeta(PokemonId.VAPOREON);
-                        PokemonMeta fla = PokemonMetaRegistry.getMeta(PokemonId.FLAREON);
-                        PokemonMeta jol = PokemonMetaRegistry.getMeta(PokemonId.JOLTEON);
-                        if (vap != null && fla != null && jol != null) {
-                            Comparator<PokemonMeta> cMeta = (m1, m2) -> {
-                                int comb1 = PokemonCpUtils.getMaxCp(m1.getBaseAttack(), m1.getBaseDefense(), m1.getBaseStamina());
-                                int comb2 = PokemonCpUtils.getMaxCp(m2.getBaseAttack(), m2.getBaseDefense(), m2.getBaseStamina());
-                                return comb1 - comb2;
-                            };
-                            highestFamilyId = PokemonId.forNumber(Collections.max(Arrays.asList(vap, fla, jol), cMeta).getNumber());
-                        }
-                    } else {
-                        // This is one of the eeveelutions, so PokemonMetaRegistry.getHightestForFamily() returns Eevee.
-                        // We correct that here
-                        highestFamilyId = p.getPokemonId();
-                    }
-                }
-
-                PokemonMeta highestFamilyMeta = PokemonMetaRegistry.getMeta(highestFamilyId);
-                if (highestFamilyId == p.getPokemonId()) {
-                    maxEvolvedCpCurrentCol.add(i.getValue(), maxCpCurrent);
-                    maxEvolvedCpCol.add(i.getValue(), maxCp);
-                    cpEvolvedCol.add(i.getValue(), "-");
-                } else if (highestFamilyMeta == null) {
-                    System.out.println("Error: Cannot find meta data for " + highestFamilyId.name());
-                } else {
-                    int attack = highestFamilyMeta.getBaseAttack() + p.getIndividualAttack();
-                    int defense = highestFamilyMeta.getBaseDefense() + p.getIndividualDefense();
-                    int stamina = highestFamilyMeta.getBaseStamina() + p.getIndividualStamina();
-                    maxEvolvedCpCurrentCol.add(i.getValue(), PokemonCpUtils.getMaxCpForTrainerLevel(attack, defense, stamina, trainerLevel));
-                    maxEvolvedCpCol.add(i.getValue(), PokemonCpUtils.getMaxCp(attack, defense, stamina));
-                    cpEvolvedCol.add(i.getValue(), String.valueOf(PokemonCpUtils.getCpForPokemonLevel(attack, defense, stamina, p.getLevel())));
-                }
-
-                int candies = 0;
-                try {
-                    candies = p.getCandy();
-                    candiesCol.add(i.getValue(), candies);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-                if (p.getCandiesToEvolve() != 0) {
-                    candies2EvlvCol.add(i.getValue(), String.valueOf(p.getCandiesToEvolve()));
-                    evolvableCol.add(i.getValue(), String.valueOf((int)((double) candies / p.getCandiesToEvolve()))); // Rounded down candies / toEvolve
-                }
-                else {
-                    candies2EvlvCol.add(i.getValue(), "-");
-                    evolvableCol.add(i.getValue(), "-");
-                }
-                dustToLevelCol.add(i.getValue(), p.getStardustCostsForPowerup());
-                pokeballCol.add(i.getValue(), WordUtils.capitalize(p.getPokeball().toString().toLowerCase().replaceAll("item_", "").replaceAll("_", " ")));
-                caughtCol.add(i.getValue(), DateHelper.toString(DateHelper.fromTimestamp(p.getCreationTimeMs())));
-                favCol.add(i.getValue(), (p.isFavorite()) ? "True" : "");
-                duelAbilityCol.add(i.getValue(), PokemonUtils.duelAbility(p, false));
-                gymOffenseCol.add(i.getValue(), PokemonUtils.gymOffense(p, false));
-                gymDefenseCol.add(i.getValue(), PokemonUtils.gymDefense(p, false));
-                duelAbilityIVCol.add(i.getValue(), PokemonUtils.duelAbility(p, true));
-                gymOffenseIVCol.add(i.getValue(), PokemonUtils.gymOffense(p, true));
-                gymDefenseIVCol.add(i.getValue(), PokemonUtils.gymDefense(p, true));
-                move1RatingCol.add(i.getValue(), PokemonUtils.moveRating(p, true));
-                move2RatingCol.add(i.getValue(), PokemonUtils.moveRating(p, false));
-                i.increment();
-            });
-        }
-
-        private Pokemon getPokemonByIndex(int i) {
-            try {
-                return pokeCol.get(pt.convertRowIndexToModel(i));
-            } catch (Exception e) {
-                e.printStackTrace();
-                return null;
-            }
-        }
-
-        @Override
-        public String getColumnName(int columnIndex) {
-            switch (columnIndex) {
-                case 0:
-                    return "Id";
-                case 1:
-                    return "Nickname";
-                case 2:
-                    return "Species";
-                case 3:
-                    return "IV %";
-                case 4:
-                    return "Lvl";
-                case 5:
-                    return "Atk";
-                case 6:
-                    return "Def";
-                case 7:
-                    return "Stam";
-                case 8:
-                    return "Type 1";
-                case 9:
-                    return "Type 2";
-                case 10:
-                    return "Move 1";
-                case 11:
-                    return "Move 2";
-                case 12:
-                    return "CP";
-                case 13:
-                    return "HP";
-                case 14:
-                    return "Max CP (Cur)";
-                case 15:
-                    return "Max CP (40)";
-                case 16:
-                    return "Max Evolved CP (Cur)";
-                case 17:
-                    return "Max Evolved CP (40)";
-                case 18:
-                    return "Candies";
-                case 19:
-                    return "To Evolve";
-                case 20:
-                    return "Stardust";
-                case 21:
-                    return "Caught With";
-                case 22:
-                    return "Time Caught";
-                case 23:
-                    return "Favorite";
-                case 24:
-                    return "Duel Ability";
-                case 25:
-                    return "Gym Offense";
-                case 26:
-                    return "Gym Defense";
-                case 27:
-                    return "Move 1 Rating";
-                case 28:
-                    return "Move 2 Rating";
-                case 29:
-                    return "CP Evolved";
-                case 30:
-                    return "Evolvable";
-                case 31:
-                    return "Duel Ability IV";
-                case 32:
-                    return "Gym Offense IV";
-                case 33:
-                    return "Gym Defense IV";
-                default:
-                    return "UNKNOWN?";
-            }
-        }
-
-        @Override
-        public int getColumnCount() {
-            return 34;
-        }
-
-        @Override
-        public int getRowCount() {
-            return pokeCol.size();
-        }
-
-        @Override
-        public Object getValueAt(int rowIndex, int columnIndex) {
-            switch (columnIndex) {
-                case 0:
-                    return numIdCol.get(rowIndex);
-                case 1:
-                    return nickCol.get(rowIndex);
-                case 2:
-                    return speciesCol.get(rowIndex);
-                case 3:
-                    return ivCol.get(rowIndex);
-                case 4:
-                    return levelCol.get(rowIndex);
-                case 5:
-                    return atkCol.get(rowIndex);
-                case 6:
-                    return defCol.get(rowIndex);
-                case 7:
-                    return stamCol.get(rowIndex);
-                case 8:
-                    return type1Col.get(rowIndex);
-                case 9:
-                    return type2Col.get(rowIndex);
-                case 10:
-                    return move1Col.get(rowIndex);
-                case 11:
-                    return move2Col.get(rowIndex);
-                case 12:
-                    return cpCol.get(rowIndex);
-                case 13:
-                    return hpCol.get(rowIndex);
-                case 14:
-                    return maxCpCurrentCol.get(rowIndex);
-                case 15:
-                    return maxCpCol.get(rowIndex);
-                case 16:
-                    return maxEvolvedCpCurrentCol.get(rowIndex);
-                case 17:
-                    return maxEvolvedCpCol.get(rowIndex);
-                case 18:
-                    return candiesCol.get(rowIndex);
-                case 19:
-                    return candies2EvlvCol.get(rowIndex);
-                case 20:
-                    return dustToLevelCol.get(rowIndex);
-                case 21:
-                    return pokeballCol.get(rowIndex);
-                case 22:
-                    return caughtCol.get(rowIndex);
-                case 23:
-                    return favCol.get(rowIndex);
-                case 24:
-                    return duelAbilityCol.get(rowIndex);
-                case 25:
-                    return gymOffenseCol.get(rowIndex);
-                case 26:
-                    return gymDefenseCol.get(rowIndex);
-                case 27:
-                    return move1RatingCol.get(rowIndex);
-                case 28:
-                    return move2RatingCol.get(rowIndex);
-                case 29:
-                    return cpEvolvedCol.get(rowIndex);
-                case 30:
-                    return evolvableCol.get(rowIndex);
-                case 31:
-                    return duelAbilityIVCol.get(rowIndex);
-                case 32:
-                    return gymOffenseIVCol.get(rowIndex);
-                case 33:
-                    return gymDefenseIVCol.get(rowIndex);
-                default:
-                    return null;
-            }
         }
     }
 }

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -333,10 +333,10 @@ public class PokemonTab extends JPanel {
             }
 
             if (!poke.getDeployedFortId().isEmpty()) {
-                System.out.println(
-                        String.format("%s with %d CP is in gym, skipping.",
-                                PokeHandler.getLocalPokeName(poke),
-                                poke.getCp()));
+                System.out.println(String.format(
+                        "%s with %d CP is in gym, skipping.",
+                        PokeHandler.getLocalPokeName(poke),
+                        poke.getCp()));
                 skipped.increment();
                 return;
             }
@@ -399,14 +399,19 @@ public class PokemonTab extends JPanel {
                 skipped = new MutableInt(),
                 success = new MutableInt(),
                 total = new MutableInt(1);
+
         selection.forEach(poke -> {
-            System.out.println("Doing Evolve " + total.getValue()
-                    + " of " + selection.size());
+            System.out.println(String.format(
+                    "Doing Evolve %d of %d",
+                    total.getValue(),
+                    selection.size()));
             total.increment();
 
             if (!poke.getDeployedFortId().isEmpty()) {
-                System.out.println(PokeHandler.getLocalPokeName(poke) + " with "
-                        + poke.getCp() + " CP is in gym, skipping.");
+                System.out.println(String.format(
+                        "%s with %d CP is in gym, skipping.",
+                        PokeHandler.getLocalPokeName(poke),
+                        +poke.getCp()));
                 skipped.increment();
                 return;
             }
@@ -421,9 +426,11 @@ public class PokemonTab extends JPanel {
                 // need to call server
                 if (candies < candiesToEvolve) {
                     err.increment();
-                    System.out.println("Error. Not enough candy to evolve "
-                            + PokeHandler.getLocalPokeName(poke) + ". "
-                            + candies + " available, " + candiesToEvolve + " needed.");
+                    System.out.println(String.format(
+                            "Error. Not enough candy to evolve %s. %d available, %d needed.",
+                            PokeHandler.getLocalPokeName(poke),
+                            candies,
+                            candiesToEvolve));
                     return;
                 }
 
@@ -433,32 +440,40 @@ public class PokemonTab extends JPanel {
                     int newCandies = newPoke.getCandy();
                     int newCp = newPoke.getCp();
                     int newHp = newPoke.getStamina();
-                    System.out.println("Evolving "
-                            + PokeHandler.getLocalPokeName(poke)
-                            + ". Evolve result: "
-                            + evolutionResultWrapper.getResult().toString());
+                    System.out.println(String.format(
+                            "Evolving %s. Evolve result: %s",
+                            PokeHandler.getLocalPokeName(poke),
+                            evolutionResultWrapper.getResult().toString()));
                     if (config.getBool(ConfigKey.TRANSFER_AFTER_EVOLVE)) {
                         ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result result = newPoke
                                 .transferPokemon();
-                        System.out.println("Transferring "
-                                + StringUtils.capitalize(newPoke.getPokemonId().toString().toLowerCase())
-                                + ", Result: " + result);
-                        System.out.println("Stat changes: " +
-                                "(Candies: " + newCandies
-                                + "[" + candies + "-" + candiesToEvolve + "]");
-
+                        System.out.println(String.format(
+                                "Transferring %s, Result: %s",
+                                StringUtils.capitalize(newPoke.getPokemonId().toString().toLowerCase()),
+                                result));
+                        System.out.println(String.format(
+                                "Stat changes: (Candies: %d[%d-%d]",
+                                newCandies,
+                                candies,
+                                candiesToEvolve));
                     } else {
-                        System.out.println("Stat changes: "
-                                + "(Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "],"
-                                + " CP: " + newCp + "[+" + (newCp - cp) + "],"
-                                + " HP: " + newHp + "[+" + (newHp - hp) + "])");
+                        System.out.println(String.format(
+                                "Stat changes: "
+                                        + "(Candies: %d[%d-%d],"
+                                        + " CP: %d[+%d],"
+                                        + " HP: %d[+%d])",
+                                newCandies, candies, candiesToEvolve,
+                                newCp, (newCp - cp),
+                                newHp, (newHp - hp)));
                     }
                     go.getInventories().updateInventories(true);
                     success.increment();
                 } else {
                     err.increment();
-                    System.out.println("Error evolving " + PokeHandler.getLocalPokeName(poke) + ", result: "
-                            + evolutionResultWrapper.getResult().toString());
+                    System.out.println(String.format(
+                            "Error evolving %s, result: %s",
+                            PokeHandler.getLocalPokeName(poke),
+                            evolutionResultWrapper.getResult().toString()));
                 }
 
                 // If not last element, sleep until the next one
@@ -469,9 +484,10 @@ public class PokemonTab extends JPanel {
                 }
             } catch (Exception e) {
                 err.increment();
-                System.out.println("Error evolving "
-                        + PokeHandler.getLocalPokeName(poke)
-                        + "! " + Utilities.getRealExceptionMessage(e));
+                System.out.println(String.format(
+                        "Error evolving %s! %s",
+                        PokeHandler.getLocalPokeName(poke),
+                        Utilities.getRealExceptionMessage(e)));
             }
         });
         try {
@@ -480,9 +496,10 @@ public class PokemonTab extends JPanel {
             e.printStackTrace();
         }
         SwingUtilities.invokeLater(this::refreshList);
-        showFinishedText("Pokémon batch evolve"
-                + (config.getBool(ConfigKey.TRANSFER_AFTER_EVOLVE) ? "/transfer" : "")
-                + " complete!", selection.size(), success, skipped, err);
+        showFinishedText(String.format(
+                "Pokémon batch evolve%s complete!",
+                (config.getBool(ConfigKey.TRANSFER_AFTER_EVOLVE) ? "/transfer" : "")),
+                selection.size(), success, skipped, err);
     }
 
     private void powerUpSelected() {

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -246,7 +246,10 @@ public class PokemonTab extends JPanel {
         PokeHandler handler = new PokeHandler(selection);
 
         BiConsumer<NicknamePokemonResponse.Result, Pokemon> perPokeCallback = (renameResult, pokemon) -> {
-            System.out.println(String.format("Doing Rename %d of %d", total.getValue(), selection.size()));
+            System.out.println(String.format(
+                    "Doing Rename %d of %d",
+                    total.getValue(),
+                    selection.size()));
             total.increment();
 
             PokeNick pokeNick = PokeHandler.generatePokemonNickname(renamePattern, pokemon);
@@ -255,7 +258,8 @@ public class PokemonTab extends JPanel {
             boolean isSkipped = (pokeNick.equals(pokemon.getNickname())
                     && renameResult.getNumber() == NicknamePokemonResponse.Result.UNSET_VALUE);
             if (isSkipped) {
-                System.out.println(String.format("Skipped renaming %s, already named %s",
+                System.out.println(String.format(
+                        "Skipped renaming %s, already named %s",
                         PokeHandler.getLocalPokeName(pokemon),
                         pokemon.getNickname()));
                 skipped.increment();
@@ -270,13 +274,15 @@ public class PokemonTab extends JPanel {
                             pokeNick.fullNickname,
                             pokeNick.toString()));
                 }
-                System.out.println(String.format("Renaming %s from \"%s\" to \"%s\", Result: Success!",
+                System.out.println(String.format(
+                        "Renaming %s from \"%s\" to \"%s\", Result: Success!",
                         PokeHandler.getLocalPokeName(pokemon),
                         pokemon.getNickname(),
                         PokeHandler.generatePokemonNickname(renamePattern, pokemon)));
             } else {
                 err.increment();
-                System.out.println(String.format("Renaming %s failed! Code: %s; Nick: %s",
+                System.out.println(String.format(
+                        "Renaming %s failed! Code: %s; Nick: %s",
                         PokeHandler.getLocalPokeName(pokemon),
                         renameResult.toString(),
                         PokeHandler.generatePokemonNickname(renamePattern, pokemon)));
@@ -315,40 +321,45 @@ public class PokemonTab extends JPanel {
                 total = new MutableInt(1);
 
         selection.forEach(poke -> {
-            System.out.println("Doing Transfer " + total.getValue() + " of " + selection.size());
+            System.out.println(String.format("Doing Transfer %d of %d", total.getValue(), selection.size()));
             total.increment();
             if (poke.isFavorite()) {
-                System.out.println(PokeHandler.getLocalPokeName(poke) + " with "
-                        + poke.getCp() + " CP is favorite, skipping.");
+                System.out.println(String.format(
+                        "%s with %d CP is favorite, skipping.",
+                        PokeHandler.getLocalPokeName(poke),
+                        poke.getCp()));
                 skipped.increment();
                 return;
             }
 
             if (!poke.getDeployedFortId().isEmpty()) {
                 System.out.println(
-                        PokeHandler.getLocalPokeName(poke) + " with "
-                                + poke.getCp() + " CP is in gym, skipping.");
+                        String.format("%s with %d CP is in gym, skipping.",
+                                PokeHandler.getLocalPokeName(poke),
+                                poke.getCp()));
                 skipped.increment();
                 return;
             }
 
             try {
                 int candies = poke.getCandy();
-                ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result transferResult = poke
-                        .transferPokemon();
+                ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result transferResult = poke.transferPokemon();
 
                 if (transferResult == ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result.SUCCESS) {
                     int newCandies = poke.getCandy();
-                    System.out.println("Transferring " + PokeHandler.getLocalPokeName(poke) + ", Result: Success!");
-                    System.out.println("Stat changes: "
-                            + "(Candies : " + newCandies
-                            + "[+" + (newCandies - candies) + "])");
+                    System.out.println(String.format(
+                            "Transferring %s, Result: Success!",
+                            PokeHandler.getLocalPokeName(poke)));
+                    System.out.println(String.format(
+                            "Stat changes: (Candies : %d[+%d])",
+                            newCandies,
+                            (newCandies - candies)));
                     success.increment();
                 } else {
-                    System.out.println("Error transferring "
-                            + PokeHandler.getLocalPokeName(poke)
-                            + ", result: "
-                            + transferResult.toString());
+                    System.out.println(String.format(
+                            "Error transferring %s, result: %s",
+                            PokeHandler.getLocalPokeName(poke),
+                            transferResult.toString()));
                     err.increment();
                 }
 
@@ -360,10 +371,10 @@ public class PokemonTab extends JPanel {
                 }
             } catch (Exception e) {
                 err.increment();
-                System.out.println("Error transferring "
-                        + PokeHandler.getLocalPokeName(poke)
-                        + "! "
-                        + Utilities.getRealExceptionMessage(e));
+                System.out.println(String.format(
+                        "Error transferring %s! %s",
+                        PokeHandler.getLocalPokeName(poke),
+                        Utilities.getRealExceptionMessage(e)));
             }
         });
         try {

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -167,9 +167,7 @@ public class PokemonTab extends JPanel {
         pokelang.setSelectedItem(locale);
         pokelang.addActionListener(e -> new SwingWorker<Void, Void>() {
             protected Void doInBackground() throws Exception {
-                @SuppressWarnings("unchecked")
-                JComboBox<String> pokelang1 = (JComboBox<String>) e.getSource();
-                String lang = (String) pokelang1.getSelectedItem();
+                String lang = (String) pokelang.getSelectedItem();
                 changeLanguage(lang);
                 return null;
             }
@@ -189,9 +187,7 @@ public class PokemonTab extends JPanel {
         fontSize.setSelectedItem(String.valueOf(size));
         fontSize.addActionListener(e -> new SwingWorker<Void, Void>() {
             protected Void doInBackground() throws Exception {
-                @SuppressWarnings("unchecked")
-                JComboBox<String> source = (JComboBox<String>) e.getSource();
-                String size = source.getSelectedItem().toString();
+                String size = fontSize.getSelectedItem().toString();
                 pt.setFont(pt.getFont().deriveFont(Float.parseFloat(size)));
                 config.setInt(ConfigKey.FONT_SIZE, Integer.parseInt(size));
                 return null;

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -246,7 +246,7 @@ public class PokemonTab extends JPanel {
         PokeHandler handler = new PokeHandler(selection);
 
         BiConsumer<NicknamePokemonResponse.Result, Pokemon> perPokeCallback = (renameResult, pokemon) -> {
-            System.out.println("Doing Rename " + total.getValue() + " of " + selection.size());
+            System.out.println(String.format("Doing Rename %d of %d", total.getValue(), selection.size()));
             total.increment();
 
             PokeNick pokeNick = PokeHandler.generatePokemonNickname(renamePattern, pokemon);
@@ -255,10 +255,9 @@ public class PokemonTab extends JPanel {
             boolean isSkipped = (pokeNick.equals(pokemon.getNickname())
                     && renameResult.getNumber() == NicknamePokemonResponse.Result.UNSET_VALUE);
             if (isSkipped) {
-                System.out.println("Skipped renaming "
-                        + PokeHandler.getLocalPokeName(pokemon)
-                        + ", already named "
-                        + pokemon.getNickname());
+                System.out.println(String.format("Skipped renaming %s, already named %s",
+                        PokeHandler.getLocalPokeName(pokemon),
+                        pokemon.getNickname()));
                 skipped.increment();
                 return;
             }
@@ -266,18 +265,21 @@ public class PokemonTab extends JPanel {
             if (renameResult.getNumber() == NicknamePokemonResponse.Result.SUCCESS_VALUE) {
                 success.increment();
                 if (pokeNick.isTooLong()) {
-                    System.out.println("WARNING: Nickname \"" + pokeNick.fullNickname
-                            + "\" is too long. Get's cut to: " + pokeNick.toString());
+                    System.out.println(String.format(
+                            "WARNING: Nickname \"%s\" is too long. Get's cut to: %s",
+                            pokeNick.fullNickname,
+                            pokeNick.toString()));
                 }
-                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon)
-                        + " from \"" + pokemon.getNickname()
-                        + "\" to \"" + PokeHandler.generatePokemonNickname(renamePattern, pokemon)
-                        + "\", Result: Success!");
+                System.out.println(String.format("Renaming %s from \"%s\" to \"%s\", Result: Success!",
+                        PokeHandler.getLocalPokeName(pokemon),
+                        pokemon.getNickname(),
+                        PokeHandler.generatePokemonNickname(renamePattern, pokemon)));
             } else {
                 err.increment();
-                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon)
-                        + " failed! Code: " + renameResult.toString()
-                        + "; Nick: " + PokeHandler.generatePokemonNickname(renamePattern, pokemon));
+                System.out.println(String.format("Renaming %s failed! Code: %s; Nick: %s",
+                        PokeHandler.getLocalPokeName(pokemon),
+                        renameResult.toString(),
+                        PokeHandler.generatePokemonNickname(renamePattern, pokemon)));
             }
 
             // If not last element and API was queried, sleep until the next one
@@ -753,8 +755,7 @@ public class PokemonTab extends JPanel {
     }
 
     /**
-     * Provide custom formatting for the moveset ranking columns while allowing
-     * sorting on original values
+     * Provide custom formatting for the moveset ranking columns while allowing sorting on original values
      */
     public static class MoveSetRankingRenderer extends JLabel implements TableCellRenderer {
 

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -616,27 +616,38 @@ public class PokemonTab extends JPanel {
         if (!confirmOperation("Toggle Favorite", selection))
             return;
 
-        MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+        MutableInt err = new MutableInt(),
+                skipped = new MutableInt(),
+                success = new MutableInt(),
                 total = new MutableInt(1);
+
         selection.forEach(poke -> {
             try {
-                System.out.println("Toggling favorite " + total.getValue() + " of " + selection.size());
+                System.out.println(String.format(
+                        "Toggling favorite %d of %d",
+                        total.getValue(),
+                        selection.size()));
                 total.increment();
                 SetFavoritePokemonResponseOuterClass.SetFavoritePokemonResponse.Result favoriteResult = poke
                         .setFavoritePokemon(!poke.isFavorite());
-                System.out.println("Attempting to set favorite for " + PokeHandler.getLocalPokeName(poke)
-                        + " to " + !poke.isFavorite() + "...");
+                System.out.println(String.format(
+                        "Attempting to set favorite for %s to %b...",
+                        PokeHandler.getLocalPokeName(poke),
+                        !poke.isFavorite()));
                 go.getPlayerProfile().updateProfile();
 
                 if (favoriteResult == SetFavoritePokemonResponseOuterClass.SetFavoritePokemonResponse.Result.SUCCESS) {
-                    System.out.println("Favorite for " + PokeHandler.getLocalPokeName(poke)
-                            + " set to " + !poke.isFavorite()
-                            + ", Result: Success!");
+                    System.out.println(String.format(
+                            "Favorite for %s set to %b, Result: Seccess!",
+                            PokeHandler.getLocalPokeName(poke),
+                            !poke.isFavorite()));
                     success.increment();
                 } else {
                     err.increment();
-                    System.out.println("Error toggling favorite for " + PokeHandler.getLocalPokeName(poke)
-                            + ", result: " + favoriteResult.toString());
+                    System.out.println(String.format(
+                            "Error toggling favorite for %s, result: %s",
+                            PokeHandler.getLocalPokeName(poke),
+                            favoriteResult.toString()));
                 }
 
                 // If not last element, sleep until the next one
@@ -647,9 +658,10 @@ public class PokemonTab extends JPanel {
                 }
             } catch (Exception e) {
                 err.increment();
-                System.out.println("Error toggling favorite for "
-                        + PokeHandler.getLocalPokeName(poke)
-                        + "! " + Utilities.getRealExceptionMessage(e));
+                System.out.println(String.format(
+                        "Error toggling favorite for %s! %s",
+                        PokeHandler.getLocalPokeName(poke),
+                        Utilities.getRealExceptionMessage(e)));
             }
         });
         try {
@@ -660,7 +672,6 @@ public class PokemonTab extends JPanel {
         SwingUtilities.invokeLater(this::refreshPkmn);
         showFinishedText("Pokémon batch \"toggle favorite\" complete!", selection.size(), success, skipped,
                 err);
-
     }
 
     private void selectLessThanIv() {

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -243,7 +243,9 @@ public class PokemonTab extends JPanel {
             return;
         String renamePattern = inputOperation("Rename", selection);
 
-        MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+        MutableInt err = new MutableInt(),
+                skipped = new MutableInt(),
+                success = new MutableInt(),
                 total = new MutableInt(1);
         PokeHandler handler = new PokeHandler(selection);
 
@@ -257,7 +259,9 @@ public class PokemonTab extends JPanel {
             boolean isSkipped = (pokeNick.equals(pokemon.getNickname())
                     && renameResult.getNumber() == NicknamePokemonResponse.Result.UNSET_VALUE);
             if (isSkipped) {
-                System.out.println("Skipped renaming " + PokeHandler.getLocalPokeName(pokemon) + ", already named "
+                System.out.println("Skipped renaming "
+                        + PokeHandler.getLocalPokeName(pokemon)
+                        + ", already named "
                         + pokemon.getNickname());
                 skipped.increment();
                 return;
@@ -266,15 +270,22 @@ public class PokemonTab extends JPanel {
             if (renameResult.getNumber() == NicknamePokemonResponse.Result.SUCCESS_VALUE) {
                 success.increment();
                 if (pokeNick.isTooLong()) {
-                    System.out.println("WARNING: Nickname \"" + pokeNick.fullNickname + "\" is too long. Get's cut to: "
+                    System.out.println("WARNING: Nickname \""
+                            + pokeNick.fullNickname
+                            + "\" is too long. Get's cut to: "
                             + pokeNick.toString());
                 }
-                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " from \""
+                System.out.println("Renaming "
+                        + PokeHandler.getLocalPokeName(pokemon)
+                        + " from \""
                         + pokemon.getNickname() + "\" to \""
-                        + PokeHandler.generatePokemonNickname(renamePattern, pokemon) + "\", Result: Success!");
+                        + PokeHandler.generatePokemonNickname(renamePattern, pokemon)
+                        + "\", Result: Success!");
             } else {
                 err.increment();
-                System.out.println("Renaming " + PokeHandler.getLocalPokeName(pokemon) + " failed! Code: "
+                System.out.println("Renaming "
+                        + PokeHandler.getLocalPokeName(pokemon)
+                        + " failed! Code: "
                         + renameResult.toString() + "; Nick: "
                         + PokeHandler.generatePokemonNickname(renamePattern, pokemon));
             }
@@ -303,20 +314,25 @@ public class PokemonTab extends JPanel {
         if (selection.size() == 0)
             return;
         if (confirmOperation("Transfer", selection)) {
-            MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+            MutableInt err = new MutableInt(),
+                    skipped = new MutableInt(),
+                    success = new MutableInt(),
                     total = new MutableInt(1);
             selection.forEach(poke -> {
                 System.out.println("Doing Transfer " + total.getValue() + " of " + selection.size());
                 total.increment();
                 if (poke.isFavorite()) {
-                    System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp()
+                    System.out.println(PokeHandler.getLocalPokeName(poke)
+                            + " with " + poke.getCp()
                             + " CP is favorite, skipping.");
                     skipped.increment();
                     return;
                 }
                 if (!poke.getDeployedFortId().isEmpty()) {
                     System.out.println(
-                            PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp() + " CP is in gym, skipping.");
+                            PokeHandler.getLocalPokeName(poke)
+                                    + " with " + poke.getCp()
+                                    + " CP is in gym, skipping.");
                     skipped.increment();
                     return;
                 }
@@ -330,10 +346,15 @@ public class PokemonTab extends JPanel {
                         int newCandies = poke.getCandy();
                         System.out.println("Transferring " + PokeHandler.getLocalPokeName(poke) + ", Result: Success!");
                         System.out.println(
-                                "Stat changes: (Candies : " + newCandies + "[+" + (newCandies - candies) + "])");
+                                "Stat changes: (Candies : "
+                                        + newCandies
+                                        + "[+" + (newCandies - candies)
+                                        + "])");
                         success.increment();
                     } else {
-                        System.out.println("Error transferring " + PokeHandler.getLocalPokeName(poke) + ", result: "
+                        System.out.println("Error transferring "
+                                + PokeHandler.getLocalPokeName(poke)
+                                + ", result: "
                                 + transferResult.toString());
                         err.increment();
                     }
@@ -346,7 +367,9 @@ public class PokemonTab extends JPanel {
                     }
                 } catch (Exception e) {
                     err.increment();
-                    System.out.println("Error transferring " + PokeHandler.getLocalPokeName(poke) + "! "
+                    System.out.println("Error transferring "
+                            + PokeHandler.getLocalPokeName(poke)
+                            + "! "
                             + Utilities.getRealExceptionMessage(e));
                 }
             });
@@ -364,13 +387,17 @@ public class PokemonTab extends JPanel {
         ArrayList<Pokemon> selection = getSelectedPokemon();
         if (selection.size() > 0) {
             if (confirmOperation("Evolve", selection)) {
-                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+                MutableInt err = new MutableInt(),
+                        skipped = new MutableInt(),
+                        success = new MutableInt(),
                         total = new MutableInt(1);
                 selection.forEach(poke -> {
-                    System.out.println("Doing Evolve " + total.getValue() + " of " + selection.size());
+                    System.out.println("Doing Evolve " + total.getValue()
+                            + " of " + selection.size());
                     total.increment();
                     if (!poke.getDeployedFortId().isEmpty()) {
-                        System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp()
+                        System.out.println(PokeHandler.getLocalPokeName(poke)
+                                + " with " + poke.getCp()
                                 + " CP is in gym, skipping.");
                         skipped.increment();
                         return;
@@ -386,8 +413,10 @@ public class PokemonTab extends JPanel {
                         // need to call server
                         if (candies < candiesToEvolve) {
                             err.increment();
-                            System.out.println("Error. Not enough candy to evolve " + PokeHandler.getLocalPokeName(poke)
-                                    + ". " + candies + " available, " + candiesToEvolve + " needed.");
+                            System.out.println("Error. Not enough candy to evolve "
+                                    + PokeHandler.getLocalPokeName(poke) + ". "
+                                    + candies + " available, "
+                                    + candiesToEvolve + " needed.");
                             return;
                         }
 
@@ -397,7 +426,9 @@ public class PokemonTab extends JPanel {
                             int newCandies = newPoke.getCandy();
                             int newCp = newPoke.getCp();
                             int newHp = newPoke.getStamina();
-                            System.out.println("Evolving " + PokeHandler.getLocalPokeName(poke) + ". Evolve result: "
+                            System.out.println("Evolving "
+                                    + PokeHandler.getLocalPokeName(poke)
+                                    + ". Evolve result: "
                                     + evolutionResultWrapper.getResult().toString());
                             if (config.getBool(ConfigKey.TRANSFER_AFTER_EVOLVE)) {
                                 ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result result = newPoke
@@ -405,12 +436,15 @@ public class PokemonTab extends JPanel {
                                 System.out.println("Transferring "
                                         + StringUtils.capitalize(newPoke.getPokemonId().toString().toLowerCase())
                                         + ", Result: " + result);
-                                System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-"
-                                        + candiesToEvolve + "]");
+                                System.out.println("Stat changes: " +
+                                        "(Candies: " + newCandies
+                                        + "[" + candies + "-" + candiesToEvolve + "]");
+
                             } else {
-                                System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-"
-                                        + candiesToEvolve + "], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp
-                                        + "[+" + (newHp - hp) + "])");
+                                System.out.println("Stat changes: "
+                                        + "(Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "],"
+                                        + " CP: " + newCp + "[+" + (newCp - cp) + "],"
+                                        + " HP: " + newHp + "[+" + (newHp - hp) + "])");
                             }
                             go.getInventories().updateInventories(true);
                             success.increment();
@@ -428,8 +462,9 @@ public class PokemonTab extends JPanel {
                         }
                     } catch (Exception e) {
                         err.increment();
-                        System.out.println("Error evolving " + PokeHandler.getLocalPokeName(poke) + "! "
-                                + Utilities.getRealExceptionMessage(e));
+                        System.out.println("Error evolving "
+                                + PokeHandler.getLocalPokeName(poke)
+                                + "! " + Utilities.getRealExceptionMessage(e));
                     }
                 });
                 try {
@@ -449,14 +484,17 @@ public class PokemonTab extends JPanel {
         ArrayList<Pokemon> selection = getSelectedPokemon();
         if (selection.size() > 0) {
             if (confirmOperation("PowerUp", selection)) {
-                MutableInt err = new MutableInt(), skipped = new MutableInt(), success = new MutableInt(),
+                MutableInt err = new MutableInt(),
+                        skipped = new MutableInt(),
+                        success = new MutableInt(),
                         total = new MutableInt(1);
                 selection.forEach(poke -> {
                     try {
                         System.out.println("Doing Power Up " + total.getValue() + " of " + selection.size());
                         total.increment();
                         if (!poke.getDeployedFortId().isEmpty()) {
-                            System.out.println(PokeHandler.getLocalPokeName(poke) + " with " + poke.getCp()
+                            System.out.println(PokeHandler.getLocalPokeName(poke)
+                                    + " with " + poke.getCp()
                                     + " CP is in gym, skipping.");
                             skipped.increment();
                             return;
@@ -474,8 +512,9 @@ public class PokemonTab extends JPanel {
                         if (candies < candiesToPowerUp || stardust < stardustToPowerUp) {
                             err.increment();
                             System.out.println("Error. Not enough candy/stardust to power up "
-                                    + PokeHandler.getLocalPokeName(poke) + ". Stardust: " + stardust + "/"
-                                    + stardustToPowerUp + ", Candy: " + candies + "/" + candiesToPowerUp);
+                                    + PokeHandler.getLocalPokeName(poke)
+                                    + ". Stardust: " + stardust + "/" + stardustToPowerUp
+                                    + ", Candy: " + candies + "/" + candiesToPowerUp);
                             return;
                         }
 
@@ -487,10 +526,12 @@ public class PokemonTab extends JPanel {
                             int newHp = poke.getMaxStamina();
                             System.out.println(
                                     "Powering Up " + PokeHandler.getLocalPokeName(poke) + ", Result: Success!");
-                            System.out.println("Stat changes: (Candies : " + newCandies + "[" + candies + "-"
-                                    + candiesToPowerUp + "], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp
-                                    + "[+" + (newHp - hp) + "]) Stardust used " + stardustToPowerUp + "[remaining: "
-                                    + go.getPlayerProfile().getCurrency(Currency.STARDUST) + "]");
+                            System.out.println("Stat changes: " +
+                                    "(Candies : " + newCandies + "[" + candies + "-" + candiesToPowerUp + "], "
+                                    + "CP: " + newCp + "[+" + (newCp - cp) + "], "
+                                    + "HP: " + newHp + "[+" + (newHp - hp) + "]) "
+                                    + "Stardust used " + stardustToPowerUp
+                                    + "[remaining: " + go.getPlayerProfile().getCurrency(Currency.STARDUST) + "]");
                             success.increment();
                         } else {
                             err.increment();
@@ -586,9 +627,9 @@ public class PokemonTab extends JPanel {
         }
         pt.clearSelection();
         System.out.println("Selecting Pokemon with IV less than: " + ivTransfer.getText());
-        
+
         for (int i = 0; i < pt.getRowCount(); i++) {
-            double pIv = Double.parseDouble((String) pt.getValueAt(i,3));
+            double pIv = Double.parseDouble((String) pt.getValueAt(i, 3));
             if (pIv < ivLessThan) {
                 pt.getSelectionModel().addSelectionInterval(i, i);
             }
@@ -707,7 +748,7 @@ public class PokemonTab extends JPanel {
                         poke.getPokeball().toString());
                 searchme = searchme.replaceAll("_FAST", "").replaceAll("FAMILY_", "").replaceAll("NONE", "")
                         .replaceAll("ITEM_", "").replaceAll("_", "").replaceAll(" ", "").toLowerCase();
-                
+
                 for (String s : terms) {
                     if (searchme.contains(s)) {
                         pokes.add(poke);


### PR DESCRIPTION
Linked with issue #65 on retaining the column ordering (at least during each session for now), considering the new UI might still take sometime to be released.

_Fix pokemon search returning wrong results due to concating of strings.
Fix select pokemon < IV
Refactored and extracted PokemonTable, PokemonTableModel
Column position persist now after calling refreshList()_

**PokemonTableModel**
- Clearly using a static number to count the columnCount was the wrong approach from the start but nobody bothered to change it.
- Same with getValueAt & getColumnName, statically coding in the return values is a pretty bad idea

**PokemonTable**
- constructNewTableModel was recreating the entire model and all the comparator on every refresh
- Thus resulting in the column reordering not persisting after a refresh.

**PokemonTab**
- Select pokemon < IV wasn't working due to trying to convert a string to double by type casting it
- Search was concating all the strings followed by contain() to find out if it matches. Causes unrelated results to be matched. E.g typing 'test', matches weedle and caterpie in my case.

And sorry for a single commit, couldn't find a suitable situation without any errors to commit a step by step changes. 
