### PR TITLE
Fix candy calculation after transfer

### DIFF
--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -385,14 +385,15 @@ public class PokemonTab extends JPanel {
                             if (config.getBool(ConfigKey.TRANSFER_AFTER_EVOLVE)) {
                                 if (newPoke.isFavorite()) {
                                     System.out.println("Skipping \"Transfer After Evolve\" for " + StringUtils.capitalize(newPoke.getPokemonId().toString().toLowerCase()) + " because favorite.");
-                                    System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp + "[+" + (newHp - hp) + "])");
+                                    System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "+1], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp + "[+" + (newHp - hp) + "])");
                                 } else {
                                     ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result result = newPoke.transferPokemon();
+                                    newCandies = newPoke.getCandy();
                                     System.out.println("Transferring " + StringUtils.capitalize(newPoke.getPokemonId().toString().toLowerCase()) + ", Result: " + result);
-                                    System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "]");
+                                    System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "+2]");
                                 }
                             } else {
-                                System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp + "[+" + (newHp - hp) + "])");
+                                System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "+1], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp + "[+" + (newHp - hp) + "])");
                             }
                             go.getInventories().updateInventories(true);
                             success.increment();

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -381,20 +381,21 @@ public class PokemonTab extends JPanel {
                             int newCandies = newPoke.getCandy();
                             int newCp = newPoke.getCp();
                             int newHp = newPoke.getStamina();
+                            int candyRefund = 1;
+                            String stats = ", CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp + "[+" + (newHp - hp) + "]";
                             System.out.println("Evolving " + PokeHandler.getLocalPokeName(poke) + ". Evolve result: " + evolutionResultWrapper.getResult().toString());
                             if (config.getBool(ConfigKey.TRANSFER_AFTER_EVOLVE)) {
                                 if (newPoke.isFavorite()) {
                                     System.out.println("Skipping \"Transfer After Evolve\" for " + StringUtils.capitalize(newPoke.getPokemonId().toString().toLowerCase()) + " because favorite.");
-                                    System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "+1], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp + "[+" + (newHp - hp) + "])");
                                 } else {
                                     ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result result = newPoke.transferPokemon();
-                                    newCandies = newPoke.getCandy();
                                     System.out.println("Transferring " + StringUtils.capitalize(newPoke.getPokemonId().toString().toLowerCase()) + ", Result: " + result);
-                                    System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "+2]");
+                                    newCandies = newPoke.getCandy();
+                                    candyRefund++;
+                                    stats = "";
                                 }
-                            } else {
-                                System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "+1], CP: " + newCp + "[+" + (newCp - cp) + "], HP: " + newHp + "[+" + (newHp - hp) + "])");
                             }
+                            System.out.println("Stat changes: (Candies: " + newCandies + "[" + candies + "-" + candiesToEvolve + "+" + candyRefund + "]" + stats + ")");
                             go.getInventories().updateInventories(true);
                             success.increment();
                         } else {

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -484,7 +484,7 @@ public class PokemonTab extends JPanel {
                     } else {
                         System.out.println(String.format(
                                 "Stat changes: "
-                                        + "(Candies: %d[%d-%d+1], "
+                                        + "(Candies: %d[%d-%d+%d], "
                                         + "CP: %d[+%d], "
                                         + "HP: %d[+%d])",
                                 newCandies, candies, candiesToEvolve, candyRefund,

--- a/src/me/corriekay/pokegoutil/windows/PokemonTab.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonTab.java
@@ -444,6 +444,7 @@ public class PokemonTab extends JPanel {
                     int newCandies = newPoke.getCandy();
                     int newCp = newPoke.getCp();
                     int newHp = newPoke.getStamina();
+                    int candyRefund = 1;
                     System.out.println(String.format(
                             "Evolving %s. Evolve result: %s",
                             PokeHandler.getLocalPokeName(poke),
@@ -456,32 +457,37 @@ public class PokemonTab extends JPanel {
 
                             System.out.println(String.format(
                                     "Stat changes: "
-                                            + "(Candies: %d[%d-%d], "
+                                            + "(Candies: %d[%d-%d+%d], "
                                             + "CP: %d[+%d], "
                                             + "HP: %d[+%d])",
-                                    newCandies, candies, candiesToEvolve,
+                                    newCandies, candies, candiesToEvolve, candyRefund,
                                     newCp, (newCp - cp),
                                     newHp, (newHp - hp)));
                         } else {
                             ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result result = newPoke
                                     .transferPokemon();
+                            if (result == ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result.SUCCESS) {
+                                newCandies = newPoke.getCandy();
+                                candyRefund++;
+                            }
                             System.out.println(String.format(
                                     "Transferring %s, Result: %s",
                                     StringUtils.capitalize(newPoke.getPokemonId().toString().toLowerCase()),
                                     result));
                             System.out.println(String.format(
-                                    "Stat changes: (Candies: %d[%d-%d]",
+                                    "Stat changes: (Candies: %d[%d-%d+%d]",
                                     newCandies,
                                     candies,
-                                    candiesToEvolve));
+                                    candiesToEvolve,
+                                    candyRefund));
                         }
                     } else {
                         System.out.println(String.format(
                                 "Stat changes: "
-                                        + "(Candies: %d[%d-%d], "
+                                        + "(Candies: %d[%d-%d+1], "
                                         + "CP: %d[+%d], "
                                         + "HP: %d[+%d])",
-                                newCandies, candies, candiesToEvolve,
+                                newCandies, candies, candiesToEvolve, candyRefund,
                                 newCp, (newCp - cp),
                                 newHp, (newHp - hp)));
                     }


### PR DESCRIPTION
Fix for https://github.com/Wolfsblvt/BlossomsPokemonGoManager/pull/319#issuecomment-241688978
Refreshed newCandies after transfer, and included refunds in the candy calculation log.
Also consolidated multiple println statements so we don't have multiple lines of code to print the same line in the log.
