### PR TITLE
Fix script for Max OS systems

### DIFF
--- a/prep/RunOnUnixLikeSystems.sh
+++ b/prep/RunOnUnixLikeSystems.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-start java -jar BlossomsPogoManager.jar
+java -jar BlossomsPogoManager.jar


### PR DESCRIPTION
"start" is no valid script option on Mac systems.
Fixes #296.
