### PR TITLE
Fixes for GymDefenseIV calculation & updating to PokeGoAPI-v0.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,19 +56,48 @@
                     </archive>
                 </configuration>
             </plugin>
+			<!-- Maven Assembly Plugin -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>2.5.4</version>
+				<configuration>
+					<!-- get all project dependencies -->
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+					<!-- MainClass in mainfest make a executable jar -->
+					<archive>
+					  <manifest>
+						<mainClass>me.corriekay.pokegoutil.BlossomsPoGoManager</mainClass>
+					  </manifest>
+					</archive>
+
+				</configuration>
+				<executions>
+				  <execution>
+					<id>make-assembly</id>
+                                        <!-- bind to the packaging phase -->
+					<phase>package</phase>
+					<goals>
+						<goal>single</goal>
+					</goals>
+				  </execution>
+				</executions>
+			</plugin>
         </plugins>
     </build>
     <repositories>
         <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
+            <id>bintray</id>
+            <url>http://jcenter.bintray.com</url>
         </repository>
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>com.github.Grover-c13</groupId>
-            <artifactId>PokeGOAPI-Java</artifactId>
-            <version>0.3</version>
+            <groupId>com.pokegoapi</groupId>
+            <artifactId>PokeGOAPI-library</artifactId>
+            <version>0.4.1</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/src/me/corriekay/pokegoutil/DATA/managers/AccountController.java
+++ b/src/me/corriekay/pokegoutil/DATA/managers/AccountController.java
@@ -179,7 +179,8 @@ public final class AccountController {
 
             if (cp != null)
                 try {
-                    go = new PokemonGo(cp, http);
+                	go = new PokemonGo(http);
+                    go.login(cp);
                 } catch (LoginFailedException | RemoteServerException e) {
                     alertFailedLogin(e.getMessage());
                     deleteLoginData(LoginType.BOTH);

--- a/src/me/corriekay/pokegoutil/DATA/managers/AccountController.java
+++ b/src/me/corriekay/pokegoutil/DATA/managers/AccountController.java
@@ -179,7 +179,7 @@ public final class AccountController {
 
             if (cp != null)
                 try {
-                	go = new PokemonGo(http);
+                    go = new PokemonGo(http);
                     go.login(cp);
                 } catch (LoginFailedException | RemoteServerException e) {
                     alertFailedLogin(e.getMessage());

--- a/src/me/corriekay/pokegoutil/DATA/managers/AccountController.java
+++ b/src/me/corriekay/pokegoutil/DATA/managers/AccountController.java
@@ -154,9 +154,14 @@ public final class AccountController {
                     refresh = true;
                 }
                 try {
-                    GoogleUserCredentialProvider provider = new GoogleUserCredentialProvider(http);
-                    if (refresh) provider.refreshToken(authCode);
-                    else provider.login(authCode);
+                    GoogleUserCredentialProvider provider;
+                    if (refresh) {
+                        // Based on usage in https://github.com/Grover-c13/PokeGOAPI-Java
+                        provider = new GoogleUserCredentialProvider(http, authCode);
+                    } else {
+                        provider = new GoogleUserCredentialProvider(http);
+                        provider.login(authCode);
+                    }
                     cp = provider;
                     if (config.getBool(ConfigKey.LOGIN_SAVE_AUTH) || checkSaveAuth()) {
                         if (!refresh)

--- a/src/me/corriekay/pokegoutil/DATA/managers/AccountManager.java
+++ b/src/me/corriekay/pokegoutil/DATA/managers/AccountManager.java
@@ -180,7 +180,8 @@ public final class AccountManager {
 
     private void prepareLogin(CredentialProvider cp, OkHttpClient http)
             throws LoginFailedException, RemoteServerException {
-        go = new PokemonGo(cp, http);
+        go = new PokemonGo(http);
+        go.login(cp);
         initOtherControllers();
     }
 

--- a/src/me/corriekay/pokegoutil/DATA/models/PokemonModel.java
+++ b/src/me/corriekay/pokegoutil/DATA/models/PokemonModel.java
@@ -101,7 +101,7 @@ public class PokemonModel {
 
         // Max CP calculation for highest evolution of current PokemonModel
         PokemonFamilyIdOuterClass.PokemonFamilyId familyId = p.getPokemonFamily();
-        PokemonIdOuterClass.PokemonId highestFamilyId = PokemonMetaRegistry.getHightestForFamily(familyId);
+        PokemonIdOuterClass.PokemonId highestFamilyId = PokemonMetaRegistry.getHighestForFamily(familyId);
 
         // Eeveelutions exception handling
         if (familyId.getNumber() == PokemonFamilyIdOuterClass.PokemonFamilyId.FAMILY_EEVEE.getNumber()) {

--- a/src/me/corriekay/pokegoutil/GUI/controller/MainWindowController.java
+++ b/src/me/corriekay/pokegoutil/GUI/controller/MainWindowController.java
@@ -98,7 +98,7 @@ public class MainWindowController extends BorderPane {
             PlayerProfile pp = accountManager.getPlayerProfile();
             stage.setTitle(String.format("%s - Stardust: %s - Blossom's Pokémon Go Manager", pp.getPlayerData().getUsername(),
                     f.format(pp.getCurrency(PlayerProfile.Currency.STARDUST))));
-        } catch (InvalidCurrencyException | LoginFailedException | RemoteServerException | NullPointerException e) {
+        } catch (NumberFormatException | NullPointerException e) {
             stage.setTitle("Blossom's Pokémon Go Manager");
         }
 

--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
@@ -197,7 +197,7 @@ public class PokeHandler {
             @Override
             public String get(Pokemon p) {
                 PokemonFamilyId familyId = p.getPokemonFamily();
-                PokemonId highestFamilyId = PokemonMetaRegistry.getHightestForFamily(familyId);
+                PokemonId highestFamilyId = PokemonMetaRegistry.getHighestForFamily(familyId);
                 int iv_attack = p.getIndividualAttack();
                 int iv_defense = p.getIndividualDefense();
                 int iv_stamina = p.getIndividualStamina();

--- a/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
+++ b/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
@@ -146,7 +146,7 @@ public class PokemonTableModel extends AbstractTableModel {
 
             // Max CP calculation for highest evolution of current Pokemon
             PokemonFamilyId familyId = p.getPokemonFamily();
-            PokemonId highestFamilyId = PokemonMetaRegistry.getHightestForFamily(familyId);
+            PokemonId highestFamilyId = PokemonMetaRegistry.getHighestForFamily(familyId);
 
             // Eeveelutions exception handling
             if (familyId.getNumber() == PokemonFamilyId.FAMILY_EEVEE.getNumber()) {

--- a/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
+++ b/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
@@ -220,7 +220,7 @@ public class PokemonTableModel extends AbstractTableModel {
             getColumnList(28).add(i.getValue(), PokemonUtils.moveRating(p, false));
             getColumnList(31).add(i.getValue(), PokemonUtils.duelAbility(p, true));
             getColumnList(32).add(i.getValue(), PokemonUtils.gymOffense(p, true));
-            getColumnList(33).add(i.getValue(), PokemonUtils.gymDefense(p, false));
+            getColumnList(33).add(i.getValue(), PokemonUtils.gymDefense(p, true));
 
             i.increment();
         });

--- a/src/me/corriekay/pokegoutil/windows/PokemonGoMainWindow.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonGoMainWindow.java
@@ -45,7 +45,7 @@ public class PokemonGoMainWindow extends JFrame {
                     go.getInventories().getHatchery().getEggs().size());
             System.out.println(msg);
 
-        } catch (RemoteServerException | LoginFailedException e) {
+        } catch (NumberFormatException | NullPointerException e) {
             // System.out.println("Unable to login!");
             // e.printStackTrace();
         }
@@ -101,7 +101,7 @@ public class PokemonGoMainWindow extends JFrame {
             setTitle(String.format("%s - Stardust: %s - Blossom's Pokémon Go Manager",
                     pp.getPlayerData().getUsername(),
                     f.format(pp.getCurrency(PlayerProfile.Currency.STARDUST))));
-        } catch (InvalidCurrencyException | LoginFailedException | RemoteServerException e) {
+        } catch (NumberFormatException | NullPointerException e) {
             setTitle("Blossom's Pokémon Go Manager");
         }
     }

--- a/src/me/corriekay/pokegoutil/windows/PokemonGoMainWindow.java
+++ b/src/me/corriekay/pokegoutil/windows/PokemonGoMainWindow.java
@@ -45,7 +45,7 @@ public class PokemonGoMainWindow extends JFrame {
                     go.getInventories().getHatchery().getEggs().size());
             System.out.println(msg);
 
-        } catch (NumberFormatException | NullPointerException e) {
+        } catch (NumberFormatException e) {
             // System.out.println("Unable to login!");
             // e.printStackTrace();
         }
@@ -101,7 +101,7 @@ public class PokemonGoMainWindow extends JFrame {
             setTitle(String.format("%s - Stardust: %s - Blossom's Pokémon Go Manager",
                     pp.getPlayerData().getUsername(),
                     f.format(pp.getCurrency(PlayerProfile.Currency.STARDUST))));
-        } catch (NumberFormatException | NullPointerException e) {
+        } catch (NumberFormatException e) {
             setTitle("Blossom's Pokémon Go Manager");
         }
     }


### PR DESCRIPTION
Two issues:
1. Fix: Gym_Defense_IV column was using non-IV calculation.
   When renaming pokemons with %gym_defense_iv_rating%, the renamed value was correct, but it differed from the Gym Defense IV column. Found that Gym Defense IV column was passing in the 'useIV' flag as 'false'. Changed it to 'true'.
2. Updating to PokeGoAPI-v0.4.1 from PokeGoAPI-v0.3
   Differences in meta registry caused wrong results for the moveset calculations. Eg. Lapras ICE_SHARD now generates 12 energy (v0.4.1), instead of 7 energy (v0.3). This caused some IV percentages to be wrong. Have checked that the weave dmg values are now the same as Prof Kukui's calculations.
