### PR TITLE
Fix charset encoding errors for console

### DIFF
--- a/prep/RunOnUnixLikeSystems.sh
+++ b/prep/RunOnUnixLikeSystems.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-java -jar BlossomsPogoManager.jar
+java -Dfile.encoding=UTF-8 -jar BlossomsPogoManager.jar

--- a/prep/RunOnWindows.bat
+++ b/prep/RunOnWindows.bat
@@ -1,1 +1,1 @@
-start java -Dfile.encoding=UTF-8 -jar BlossomsPogoManager.jar
+start javaw -Dfile.encoding=UTF-8 -jar BlossomsPogoManager.jar

--- a/prep/RunOnWindows.bat
+++ b/prep/RunOnWindows.bat
@@ -1,1 +1,1 @@
-start javaw -jar BlossomsPogoManager.jar
+start java -Dfile.encoding=UTF-8 -jar BlossomsPogoManager.jar

--- a/src/me/corriekay/pokegoutil/data/managers/GlobalSettingsController.java
+++ b/src/me/corriekay/pokegoutil/data/managers/GlobalSettingsController.java
@@ -48,7 +48,6 @@ public final class GlobalSettingsController {
     private void consoleSetup() {
         logController = new LogController();
         ConsolePrintStream.setup(logController);
-        setDefaultCharset("UTF8");
     }
 
     /**
@@ -58,20 +57,5 @@ public final class GlobalSettingsController {
      */
     public LogController getLogController() {
         return logController;
-    }
-
-    /**
-     * Set the default charset for the console, so that characters are displayed correctly.
-     *
-     * @param charsetName The name of the charset.
-     */
-    private void setDefaultCharset(final String charsetName) {
-        try {
-            final Field charset = Charset.class.getDeclaredField("defaultCharset");
-            charset.setAccessible(true);
-            charset.set(null, Charset.forName(charsetName));
-        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException ex) {
-            ConsolePrintStream.printException(ex);
-        }
     }
 }


### PR DESCRIPTION
On many systems characters in the console aren't displayed correctly. This should fix it.
(If the scripts are used to run the tool of course)
