### PR TITLE
Moved PokeColumn + bit refactoring & codes style

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -269,7 +269,10 @@
             <property name="severity" value="warning"/>
             <property name="format" value="(TODO)|(FIXME)"/>
         </module>
-        <module name="TrailingComment"/>
+        <module name="TrailingComment">
+            <!-- We allow trailing comments on "case xxx:" lines too, to describe what the case does. -->
+            <property name="format" value="^((\s*)|(\s*case(.*?):\s*))$"/>
+        </module>
         <module name="UncommentedMain">
             <property name="excludedClasses" value="\.Main$"/>
         </module>

--- a/src/me/corriekay/pokegoutil/data/enums/ColumnType.java
+++ b/src/me/corriekay/pokegoutil/data/enums/ColumnType.java
@@ -4,60 +4,73 @@ import java.util.Comparator;
 
 import javax.swing.table.TableCellRenderer;
 
+import me.corriekay.pokegoutil.utils.StringLiterals;
 import me.corriekay.pokegoutil.utils.helpers.DateHelper;
 import me.corriekay.pokegoutil.utils.windows.renderer.DefaultCellRenderer;
 import me.corriekay.pokegoutil.utils.windows.renderer.NumberCellRenderer;
 import me.corriekay.pokegoutil.utils.windows.renderer.PercentageCellRenderer;
 
-
+/**
+ * Enum that defines all possible column types for table columns.
+ */
 public enum ColumnType {
     DATE(
         String.class,
-        Comparators.dateStringComparator
+        Comparators.DATE_STRING
     ),
     INT(
         Integer.class,
-        Comparators.intComparator,
-        CellRenderers.numberCellRenderer
+        Comparators.INT,
+        CellRenderers.NUMBER
+    ),
+    LONG(
+        Integer.class,
+        Comparators.LONG,
+        CellRenderers.NUMBER
     ),
     DOUBLE(
         Double.class,
-        Comparators.doubleComparator,
-        CellRenderers.numberCellRenderer
+        Comparators.DOUBLE,
+        CellRenderers.NUMBER
     ),
     NULLABLE_INT(
         String.class,
-        Comparators.nullableIntComparator,
-        CellRenderers.numberCellRenderer
+        Comparators.NULLABLE_INT,
+        CellRenderers.NUMBER
     ),
     PERCENTAGE(
         Double.class,
-        Comparators.doubleComparator,
-        CellRenderers.percentageCellRenderer
+        Comparators.DOUBLE,
+        CellRenderers.PERCENTAGE
     ),
     STRING(
         String.class,
-        Comparators.stringComparator
+        Comparators.STRING
     );
+
+    public final Class clazz;
+    public final Comparator comparator;
+    public final TableCellRenderer tableCellRenderer;
 
     /**
      * This private class is needed to create the comparators that are used in this enum.
      */
     private static final class Comparators {
         // The comparators.
-        public static final Comparator<String> dateStringComparator = (date1, date2) -> DateHelper.fromString(date1)
+        private static final Comparator<String> DATE_STRING = (date1, date2) -> DateHelper.fromString(date1)
             .compareTo(DateHelper.fromString(date2));
-        public static final Comparator<Double> doubleComparator = Double::compareTo;
-        public static final Comparator<Integer> intComparator = Integer::compareTo;
-        public static final Comparator<String> stringComparator = String::compareTo;
-        public static final Comparator<String> nullableIntComparator = (s1, s2) -> {
-            if ("-".equals(s1)) {
-                s1 = "0";
+        private static final Comparator<Double> DOUBLE = Double::compareTo;
+        private static final Comparator<Integer> INT = Integer::compareTo;
+        private static final Comparator<Long> LONG = Long::compareTo;
+        private static final Comparator<String> STRING = String::compareTo;
+        private static final Comparator<String> NULLABLE_INT = (left, right) -> {
+            if (StringLiterals.NO_VALUE_SIGN.equals(left)) {
+                left = String.valueOf(0);
             }
-            if ("-".equals(s2)) {
-                s2 = "0";
+            if (StringLiterals.NO_VALUE_SIGN.equals(right)) {
+                right = String.valueOf(0);
             }
-            return Integer.compare(Integer.parseInt(s1), Integer.parseInt(s2));
+            return Integer.compare(Integer.parseInt(left), Integer.parseInt(right));
         };
     }
 
@@ -65,15 +78,10 @@ public enum ColumnType {
      * This private class is needed to create the cell renderers that are used in this enum.
      */
     private static final class CellRenderers {
-        public static final DefaultCellRenderer defaultCellRenderer = new DefaultCellRenderer();
-        public static final NumberCellRenderer numberCellRenderer = new NumberCellRenderer();
-        public static final PercentageCellRenderer percentageCellRenderer = new PercentageCellRenderer();
+        public static final DefaultCellRenderer DEFAULT = new DefaultCellRenderer();
+        public static final NumberCellRenderer NUMBER = new NumberCellRenderer();
+        public static final PercentageCellRenderer PERCENTAGE = new PercentageCellRenderer();
     }
-
-
-    public final Class clazz;
-    public final Comparator comparator;
-    public final TableCellRenderer tableCellRenderer;
 
     /**
      * Constructor to create a column type enum field.
@@ -82,7 +90,7 @@ public enum ColumnType {
      * @param comparator The comparator for that column.
      */
     ColumnType(final Class clazz, final Comparator comparator) {
-        this(clazz, comparator, CellRenderers.defaultCellRenderer);
+        this(clazz, comparator, CellRenderers.DEFAULT);
     }
 
     /**

--- a/src/me/corriekay/pokegoutil/data/enums/LoginType.java
+++ b/src/me/corriekay/pokegoutil/data/enums/LoginType.java
@@ -1,5 +1,8 @@
 package me.corriekay.pokegoutil.data.enums;
 
+/**
+ * An enum containing all different login types.
+ */
 public enum LoginType {
     GOOGLE_AUTH,
     GOOGLE_APP_PASSWORD,
@@ -14,7 +17,7 @@ public enum LoginType {
      * @param loginType The given login type.
      * @return Weather or not the login type is google.
      */
-    public static boolean isGoogle(LoginType loginType) {
+    public static boolean isGoogle(final LoginType loginType) {
         return loginType == GOOGLE_APP_PASSWORD || loginType == GOOGLE_AUTH;
     }
 }

--- a/src/me/corriekay/pokegoutil/data/enums/PokeColumn.java
+++ b/src/me/corriekay/pokegoutil/data/enums/PokeColumn.java
@@ -1,4 +1,4 @@
-package me.corriekay.pokegoutil.utils.windows;
+package me.corriekay.pokegoutil.data.enums;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -9,7 +9,6 @@ import javax.swing.table.TableCellRenderer;
 import com.pokegoapi.api.pokemon.Pokemon;
 import com.pokegoapi.exceptions.NoSuchItemException;
 
-import me.corriekay.pokegoutil.data.enums.ColumnType;
 import me.corriekay.pokegoutil.utils.ConfigKey;
 import me.corriekay.pokegoutil.utils.ConfigNew;
 import me.corriekay.pokegoutil.utils.StringLiterals;
@@ -17,8 +16,8 @@ import me.corriekay.pokegoutil.utils.Utilities;
 import me.corriekay.pokegoutil.utils.helpers.CollectionHelper;
 import me.corriekay.pokegoutil.utils.helpers.DateHelper;
 import me.corriekay.pokegoutil.utils.pokemon.PokemonCalculationUtils;
-import me.corriekay.pokegoutil.utils.pokemon.PokemonUtils;
 import me.corriekay.pokegoutil.utils.pokemon.PokemonPerformanceCache;
+import me.corriekay.pokegoutil.utils.pokemon.PokemonUtils;
 
 /**
  * A class that holds data relevant for each column.

--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
@@ -13,10 +13,10 @@ import com.pokegoapi.api.pokemon.PokemonMoveMetaRegistry;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 
+import me.corriekay.pokegoutil.data.enums.PokeColumn;
 import me.corriekay.pokegoutil.utils.StringLiterals;
 import me.corriekay.pokegoutil.utils.Utilities;
 import me.corriekay.pokegoutil.utils.helpers.UnicodeHelper;
-import me.corriekay.pokegoutil.utils.windows.PokeColumn;
 
 import POGOProtos.Networking.Responses.NicknamePokemonResponseOuterClass.NicknamePokemonResponse;
 

--- a/src/me/corriekay/pokegoutil/utils/version/Updater.java
+++ b/src/me/corriekay/pokegoutil/utils/version/Updater.java
@@ -18,7 +18,7 @@ import me.corriekay.pokegoutil.utils.version.thirdparty.ComparableVersion;
 /**
  * An Updater which checks for a newer stable version on GitHub, of this tool.
  */
-public class Updater {
+public final class Updater {
 
     public static final String VERSION_FILENAME = "version.txt";
     public static final String LATEST_VERSION_URL = "https://raw.githubusercontent.com/wolfsblvt/BlossomsPokemonGoManager/master/src/main/resources/";
@@ -37,9 +37,9 @@ public class Updater {
      */
     private Updater() {
         // Read the local version file as version
-        ClassLoader classLoader = getClass().getClassLoader();
-        InputStream inputStream = classLoader.getResourceAsStream(VERSION_FILENAME);
-        String versionString = readVersionFile(inputStream);
+        final ClassLoader classLoader = getClass().getClassLoader();
+        final InputStream inputStream = classLoader.getResourceAsStream(VERSION_FILENAME);
+        final String versionString = readVersionFile(inputStream);
         currentVersion = new ComparableVersion(versionString);
         System.out.println("Current version: " + versionString);
     }
@@ -72,10 +72,10 @@ public class Updater {
      * Tries to save it locally under latestStable.
      */
     public void queryLatestVersion() {
-        String callUrl = LATEST_VERSION_URL + VERSION_FILENAME;
+        final String callUrl = LATEST_VERSION_URL + VERSION_FILENAME;
         try {
-            URL url = new URL(callUrl);
-            String latestVersionString = readVersionFile(url.openStream());
+            final URL url = new URL(callUrl);
+            final String latestVersionString = readVersionFile(url.openStream());
             latestStable = new ComparableVersion(latestVersionString);
             System.out.println("Latest version from server: " + latestVersionString);
         } catch (IOException ex) {
@@ -106,7 +106,7 @@ public class Updater {
     public void checkForNewVersion() {
         queryLatestVersion();
         if (hasNewerVersion()) {
-            String skipVersion = config.getString(ConfigKey.SKIP_VERSION);
+            final String skipVersion = config.getString(ConfigKey.SKIP_VERSION);
             if (!latestStable.toString().equals(skipVersion)) {
                 final String versionFoundString = "New version found! Version: ";
                 System.out.println(versionFoundString + latestStable.toString());
@@ -116,24 +116,24 @@ public class Updater {
                     config.delete(ConfigKey.SKIP_VERSION);
                 }
 
-                String message = "A new version was found on GitHub." + StringLiterals.NEWLINE
-                        + "Version: " + latestStable + StringLiterals.NEWLINE
-                        + StringLiterals.NEWLINE
-                        + "Your current version: " + currentVersion + StringLiterals.NEWLINE
-                        + StringLiterals.NEWLINE
-                        + "It should be updated." + StringLiterals.NEWLINE
-                        + "Click 'Download' to be redirected to GitHub where you can download the new version." + StringLiterals.NEWLINE
-                        + "Click 'Later' to be reminded on next program start." + StringLiterals.NEWLINE
-                        + "Click 'Ignore' and you won't be notified again until the next version releases.";
+                final String message = "A new version was found on GitHub." + StringLiterals.NEWLINE
+                    + "Version: " + latestStable + StringLiterals.NEWLINE
+                    + StringLiterals.NEWLINE
+                    + "Your current version: " + currentVersion + StringLiterals.NEWLINE
+                    + StringLiterals.NEWLINE
+                    + "It should be updated." + StringLiterals.NEWLINE
+                    + "Click 'Download' to be redirected to GitHub where you can download the new version." + StringLiterals.NEWLINE
+                    + "Click 'Later' to be reminded on next program start." + StringLiterals.NEWLINE
+                    + "Click 'Ignore' and you won't be notified again until the next version releases.";
 
-                String[] options = new String[]{"Download", "Later", "Ignore this Version"};
-                int response = JOptionPane.showOptionDialog(null, message, versionFoundString,
-                        JOptionPane.DEFAULT_OPTION, JOptionPane.PLAIN_MESSAGE,
-                        null, options, options[0]);
+                final String[] options = new String[] {"Download", "Later", "Ignore this Version"};
+                final int response = JOptionPane.showOptionDialog(null, message, versionFoundString,
+                    JOptionPane.DEFAULT_OPTION, JOptionPane.PLAIN_MESSAGE,
+                    null, options, options[0]);
 
                 switch (response) {
                     case 0: // Download
-                        String latestReleaseUrl = "https://github.com/Wolfsblvt/BlossomsPokemonGoManager/releases/latest";
+                        final String latestReleaseUrl = "https://github.com/Wolfsblvt/BlossomsPokemonGoManager/releases/latest";
                         Browser.openUrl(latestReleaseUrl);
                         System.exit(0);
                         break;
@@ -160,11 +160,11 @@ public class Updater {
      * @param inputStream The InputStream of the version file.
      * @return The version string.
      */
-    private String readVersionFile(InputStream inputStream) {
+    private String readVersionFile(final InputStream inputStream) {
         String str;
-        StringBuilder buf = new StringBuilder();
+        final StringBuilder buf = new StringBuilder();
         try {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
             while ((str = reader.readLine()) != null) {
                 buf.append(str).append("\n");
             }
@@ -173,7 +173,8 @@ public class Updater {
         } finally {
             try {
                 inputStream.close();
-            } catch (Throwable ignore) {
+            } catch (IOException ignored) {
+                // If the input steam can't be closed... we don't care, sorry.
             }
         }
         return buf.toString().trim();

--- a/src/me/corriekay/pokegoutil/utils/windows/PokemonTable.java
+++ b/src/me/corriekay/pokegoutil/utils/windows/PokemonTable.java
@@ -1,21 +1,25 @@
 package me.corriekay.pokegoutil.utils.windows;
 
-import com.pokegoapi.api.PokemonGo;
-import com.pokegoapi.api.pokemon.Pokemon;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
 
-import me.corriekay.pokegoutil.utils.ConfigKey;
-import me.corriekay.pokegoutil.utils.ConfigNew;
-import me.corriekay.pokegoutil.utils.helpers.JTableColumnPacker;
-
-import javax.swing.*;
+import javax.swing.JTable;
+import javax.swing.ListSelectionModel;
+import javax.swing.RowSorter;
 import javax.swing.RowSorter.SortKey;
+import javax.swing.SortOrder;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
 
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
+import com.pokegoapi.api.PokemonGo;
+import com.pokegoapi.api.pokemon.Pokemon;
+
+import me.corriekay.pokegoutil.data.enums.PokeColumn;
+import me.corriekay.pokegoutil.utils.ConfigKey;
+import me.corriekay.pokegoutil.utils.ConfigNew;
+import me.corriekay.pokegoutil.utils.helpers.JTableColumnPacker;
 
 @SuppressWarnings("serial")
 public class PokemonTable extends JTable {

--- a/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
+++ b/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
@@ -10,6 +10,8 @@ import org.apache.commons.lang3.mutable.MutableInt;
 import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.api.pokemon.Pokemon;
 
+import me.corriekay.pokegoutil.data.enums.PokeColumn;
+
 @SuppressWarnings( {"serial", "rawtypes"})
 
 public class PokemonTableModel extends AbstractTableModel {


### PR DESCRIPTION
`PokeColumn` is an enum, even if it is directly related to the TableModel and stuff. So I moved it to the enum package.

Refactored some more small classes.

Allowed trailing comments for `case xxx:` statements, which makes it easier to leave a short note what this case block is for. The are even aligned and well formatted, so they do not match the rationale why trailing comments are to be avoided.
