### PR TITLE
Added IV Sum and Diff rename patterns

### DIFF
--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
@@ -22,6 +22,7 @@ import POGOProtos.Networking.Responses.NicknamePokemonResponseOuterClass.Nicknam
 
 public class PokeHandler {
 
+    public static final int MAX_IVS = 45;
     private final ArrayList<Pokemon> mons;
 
     public PokeHandler(final Pokemon pokemon) {
@@ -185,20 +186,20 @@ public class PokeHandler {
                     + Integer.toHexString((int) PokeColumn.IV_STAMINA.get(p))).toUpperCase();
             }
         },
-        IV_SUM("Sum of the IV values (00 - 45)"){
+        IV_SUM("Sum of the IV values (00 - 45)") {
             @Override
-            public String get(Pokemon p){
-                Integer sum = p.getIndividualAttack() + p.getIndividualDefense() + p.getIndividualStamina();
-                String unf = sum.toString();
+            public String get(Pokemon p) {
+                final Integer sum = p.getIndividualAttack() + p.getIndividualDefense() + p.getIndividualStamina();
+                final String unf = sum.toString();
                 return StringUtils.leftPad(unf, 2, '0');
             }
         },
-        IV_DIFF("The amount of IV missing (00-45)"){
+        IV_DIFF("The amount of IV missing (00-45)") {
             @Override
-            public String get(Pokemon p){
-                int sum = p.getIndividualAttack() + p.getIndividualDefense() + p.getIndividualStamina();
-                Integer diff = 45 - sum;
-                String unf = diff.toString();
+            public String get(Pokemon p) {
+                final int sum = p.getIndividualAttack() + p.getIndividualDefense() + p.getIndividualStamina();
+                final Integer diff = MAX_IVS - sum;
+                final String unf = diff.toString();
                 return StringUtils.leftPad(unf, 2, '0');
             }
         },

--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
@@ -185,6 +185,23 @@ public class PokeHandler {
                     + Integer.toHexString((int) PokeColumn.IV_STAMINA.get(p))).toUpperCase();
             }
         },
+        IV_SUM("Sum of the IV values (00 - 45)"){
+            @Override
+            public String get(Pokemon p){
+                Integer sum = p.getIndividualAttack() + p.getIndividualDefense() + p.getIndividualStamina();
+                String unf = sum.toString();
+                return StringUtils.leftPad(unf, 2, '0');
+            }
+        },
+        IV_DIFF("The amount of IV missing (00-45)"){
+            @Override
+            public String get(Pokemon p){
+                int sum = p.getIndividualAttack() + p.getIndividualDefense() + p.getIndividualStamina();
+                Integer diff = 45 - sum;
+                String unf = diff.toString();
+                return StringUtils.leftPad(unf, 2, '0');
+            }
+        },
         IV_ATT("IV Attack") {
             @Override
             public String get(final Pokemon p) {


### PR DESCRIPTION
For sorting purposes, especially Diff, can be useful to see which Pokemon have high IVs.  Sorting by A-Z with IV_DIFF will make the highest-IVs come to the top.  Also, max and min are always 2 digits and there are no decimals.
