### PR TITLE
Fix Level Column and Rename Patterns

### DIFF
--- a/src/me/corriekay/pokegoutil/data/enums/PokeColumn.java
+++ b/src/me/corriekay/pokegoutil/data/enums/PokeColumn.java
@@ -65,7 +65,7 @@ public enum PokeColumn {
     LEVEL("Lvl", ColumnType.DOUBLE) {
         @Override
         public Object get(final Pokemon p) {
-            return p.getLevel();
+            return (double) p.getLevel();
         }
     },
     IV_ATTACK("Atk", ColumnType.INT) {

--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
@@ -382,7 +382,7 @@ public class PokeHandler {
          * @return The two-length-number.
          */
         private static String pad(final int number, final int length) {
-            final int max = 10 * length;
+            final int max = (int) Math.pow(10, length);
             return (number < max) ? StringUtils.leftPad(String.valueOf(number), length, '0') : StringUtils.repeat('X', length);
         }
 


### PR DESCRIPTION
Fix Level column couldn't be sorted, threw an exception.
Fixes rename patterns with padding/XX.

Fixes #446.
