### PR TITLE
update to the latest version of PokeGOAPI-Java in order to support gen2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>com.github.Grover-c13</groupId>
             <artifactId>PokeGOAPI-Java</artifactId>
-            <version>7317a049fe3cbb38e219e0056c21b29505133db4</version>
+            <version>37b88d41dda745e06319b79a211dbd8492f165e3</version>
         </dependency>
 <!--         <dependency> -->
 <!--             <groupId>com.github.Wolfsblvt</groupId> -->

--- a/src/me/corriekay/pokegoutil/data/enums/PokeColumn.java
+++ b/src/me/corriekay/pokegoutil/data/enums/PokeColumn.java
@@ -93,13 +93,13 @@ public enum PokeColumn {
     TYPE_1("Type 1", ColumnType.STRING) {
         @Override
         public Object get(final Pokemon p) {
-            return PokemonUtils.formatType(p.getMeta().getType1());
+            return PokemonUtils.formatType(PokemonUtils.getSettings(p).getType());
         }
     },
     TYPE_2("Type 2", ColumnType.STRING) {
         @Override
         public Object get(final Pokemon p) {
-            return PokemonUtils.formatType(p.getMeta().getType2());
+            return PokemonUtils.formatType(PokemonUtils.getSettings(p).getType2());
         }
     },
     MOVE_1("Move 1", ColumnType.STRING) {

--- a/src/me/corriekay/pokegoutil/data/managers/AccountController.java
+++ b/src/me/corriekay/pokegoutil/data/managers/AccountController.java
@@ -25,6 +25,8 @@ import com.pokegoapi.exceptions.AsyncPokemonGoException;
 import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
+import com.pokegoapi.exceptions.hash.HashException;
+import com.pokegoapi.util.hash.legacy.LegacyHashProvider;
 
 import me.corriekay.pokegoutil.data.enums.LoginType;
 import me.corriekay.pokegoutil.utils.ConfigKey;
@@ -334,12 +336,12 @@ public final class AccountController {
                     if (config.getBool(ConfigKey.DEVICE_INFO_USE_CUSTOM)) {
                         go.setDeviceInfo(new DeviceInfo(new CustomDeviceInfo()));
                     }
-                    go.login(credentialProvider);
+                    go.login(credentialProvider, new LegacyHashProvider());
                 } else {
                     throw new IllegalStateException("credentialProvider is null.");
                 }
                 instance.logged = true;
-            } catch (LoginFailedException | RemoteServerException | AsyncPokemonGoException | IllegalStateException | CaptchaActiveException e) {
+            } catch (HashException | LoginFailedException | RemoteServerException | AsyncPokemonGoException | IllegalStateException | CaptchaActiveException e) {
                 alertFailedLogin(e.getClass().getSimpleName(), e.getMessage(), tries);
                 e.printStackTrace();
                 // deleteLoginData(LoginType.ALL);

--- a/src/me/corriekay/pokegoutil/data/managers/AccountManager.java
+++ b/src/me/corriekay/pokegoutil/data/managers/AccountManager.java
@@ -9,6 +9,8 @@ import com.pokegoapi.auth.PtcCredentialProvider;
 import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
+import com.pokegoapi.exceptions.hash.HashException;
+import com.pokegoapi.util.hash.legacy.LegacyHashProvider;
 
 import me.corriekay.pokegoutil.data.enums.LoginType;
 import me.corriekay.pokegoutil.data.models.BpmResult;
@@ -188,7 +190,7 @@ public final class AccountManager {
         try {
             prepareLogin(cp, http);
             return new BpmResult();
-        } catch (LoginFailedException | RemoteServerException | CaptchaActiveException e) {
+        } catch (HashException | LoginFailedException | RemoteServerException | CaptchaActiveException e) {
             deleteLoginData(LoginType.ALL);
             return new BpmResult(e.getMessage());
         }
@@ -225,7 +227,7 @@ public final class AccountManager {
         try {
             prepareLogin(cp, http);
             return new BpmResult();
-        } catch (LoginFailedException | RemoteServerException | CaptchaActiveException e) {
+        } catch (HashException | LoginFailedException | RemoteServerException | CaptchaActiveException e) {
             deleteLoginData(LoginType.ALL);
             return new BpmResult(e.getMessage());
         }
@@ -241,12 +243,12 @@ public final class AccountManager {
      * @throws CaptchaActiveException captcha active error
      */
     private void prepareLogin(final CredentialProvider cp, final OkHttpClient http)
-            throws LoginFailedException, RemoteServerException, CaptchaActiveException {
+        throws LoginFailedException, RemoteServerException, CaptchaActiveException, HashException {
         go = new PokemonGo(http);
         if (config.getBool(ConfigKey.DEVICE_INFO_USE_CUSTOM)) {
             go.setDeviceInfo(new DeviceInfo(new CustomDeviceInfo()));
         }
-        go.login(cp);
+        go.login(cp, new LegacyHashProvider());
         playerAccount = new PlayerAccount(go.getPlayerProfile());
         initOtherControllers();
     }

--- a/src/me/corriekay/pokegoutil/data/models/operations/EvolveOperation.java
+++ b/src/me/corriekay/pokegoutil/data/models/operations/EvolveOperation.java
@@ -5,6 +5,7 @@ import com.pokegoapi.api.pokemon.Pokemon;
 import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
+import com.pokegoapi.exceptions.hash.HashException;
 
 import me.corriekay.pokegoutil.data.enums.OperationError;
 import me.corriekay.pokegoutil.data.models.BpmOperationResult;
@@ -39,7 +40,7 @@ public class EvolveOperation extends Operation {
         final String erroEvolvingString = "Error evolving %s, result: %s";
         try {
             evolutionResult = pokemon.getPokemon().evolve();
-        } catch (CaptchaActiveException e) {
+        } catch (HashException | CaptchaActiveException e) {
             e.printStackTrace();
             return new BpmOperationResult(String.format(
                     erroEvolvingString,

--- a/src/me/corriekay/pokegoutil/data/models/operations/TransferOperation.java
+++ b/src/me/corriekay/pokegoutil/data/models/operations/TransferOperation.java
@@ -4,6 +4,7 @@ import com.pokegoapi.api.pokemon.Pokemon;
 import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
+import com.pokegoapi.exceptions.hash.HashException;
 
 import POGOProtos.Networking.Responses.ReleasePokemonResponseOuterClass.ReleasePokemonResponse.Result;
 import me.corriekay.pokegoutil.data.enums.OperationError;
@@ -42,7 +43,7 @@ public class TransferOperation extends Operation {
         final String errorTransferingString = "Error transferring %s, result: %s";
         try {
             transferResult = poke.transferPokemon();
-        } catch (CaptchaActiveException e) {
+        } catch (HashException | CaptchaActiveException e) {
             e.printStackTrace();
             return new BpmOperationResult(String.format(
                     errorTransferingString,

--- a/src/me/corriekay/pokegoutil/utils/helpers/UnicodeHelper.java
+++ b/src/me/corriekay/pokegoutil/utils/helpers/UnicodeHelper.java
@@ -1,6 +1,6 @@
 package me.corriekay.pokegoutil.utils.helpers;
 
-import com.pokegoapi.api.pokemon.PokemonType;
+import POGOProtos.Enums.PokemonTypeOuterClass;
 
 /** Class to Help get the Unicode character.
  * @author Fernando */
@@ -21,24 +21,24 @@ public enum UnicodeHelper {
     NUMBER_13(0x24ED, "13"),
     NUMBER_14(0x24EE, "14"),
     NUMBER_15(0x24EF, "15"),
-    TYPE_BUG(0x2042, PokemonType.BUG.toString()),
-    TYPE_DARK(0x263D, PokemonType.DARK.toString()),
-    TYPE_DRAGON(0x26E9, PokemonType.DRAGON.toString()),
-    TYPE_ELETRIC(0x2607, PokemonType.ELECTRIC.toString()),
-    TYPE_FAIRY(0x2764, PokemonType.FAIRY.toString()),
-    TYPE_FIGHTING(0x270A, PokemonType.FIGHTING.toString()),
-    TYPE_FIRE(0x2668, PokemonType.FIRE.toString()),
-    TYPE_FLYING(0x2708, PokemonType.FLYING.toString()),
-    TYPE_GHOST(0x26B0, PokemonType.GHOST.toString()),
-    TYPE_GRASS(0x2E19, PokemonType.GRASS.toString()),
-    TYPE_GROUND(0x26F0, PokemonType.GROUND.toString()),
-    TYPE_ICE(0x2744, PokemonType.ICE.toString()),
-    TYPE_NORMAL(0x2734, PokemonType.NORMAL.toString()),
-    TYPE_POISON(0x2620, PokemonType.POISON.toString()),
-    TYPE_PSYCHIC(0x269B, PokemonType.PSYCHIC.toString()),
-    TYPE_ROCK(0x25C9, PokemonType.ROCK.toString()),
-    TYPE_STEEL(0x26D3, PokemonType.STEEL.toString()),
-    TYPE_WATER(0x26C6, PokemonType.WATER.toString()),
+    TYPE_BUG(0x2042, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_BUG.toString()),
+    TYPE_DARK(0x263D, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_DARK.toString()),
+    TYPE_DRAGON(0x26E9, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_DRAGON.toString()),
+    TYPE_ELETRIC(0x2607, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_ELECTRIC.toString()),
+    TYPE_FAIRY(0x2764, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_FAIRY.toString()),
+    TYPE_FIGHTING(0x270A, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_FIGHTING.toString()),
+    TYPE_FIRE(0x2668, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_FIRE.toString()),
+    TYPE_FLYING(0x2708, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_FLYING.toString()),
+    TYPE_GHOST(0x26B0, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_GHOST.toString()),
+    TYPE_GRASS(0x2E19, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_GRASS.toString()),
+    TYPE_GROUND(0x26F0, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_GROUND.toString()),
+    TYPE_ICE(0x2744, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_ICE.toString()),
+    TYPE_NORMAL(0x2734, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_NORMAL.toString()),
+    TYPE_POISON(0x2620, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_POISON.toString()),
+    TYPE_PSYCHIC(0x269B, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_PSYCHIC.toString()),
+    TYPE_ROCK(0x25C9, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_ROCK.toString()),
+    TYPE_STEEL(0x26D3, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_STEEL.toString()),
+    TYPE_WATER(0x26C6, PokemonTypeOuterClass.PokemonType.POKEMON_TYPE_WATER.toString()),
     SHIELD(0x26E8, "shield"),
     SWORD(0x2694, "sword");
 

--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokeHandler.java
@@ -9,10 +9,10 @@ import java.util.function.BiConsumer;
 import org.apache.commons.lang3.StringUtils;
 
 import com.pokegoapi.api.pokemon.Pokemon;
-import com.pokegoapi.api.pokemon.PokemonMoveMetaRegistry;
 import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
+import com.pokegoapi.exceptions.hash.HashException;
 
 import me.corriekay.pokegoutil.data.enums.PokeColumn;
 import me.corriekay.pokegoutil.utils.Utilities;
@@ -62,7 +62,7 @@ public class PokeHandler {
         try {
             final NicknamePokemonResponse.Result result = pokemon.renamePokemon(pokeNick.toString());
             return result;
-        } catch (LoginFailedException | RemoteServerException | CaptchaActiveException e) {
+        } catch (LoginFailedException | RemoteServerException | CaptchaActiveException | HashException e ) {
             System.out.println("Error while renaming "
                 + PokemonUtils.getLocalPokeName(pokemon) + "(" + pokemon.getNickname() + ")! "
                 + Utilities.getRealExceptionMessage(e));
@@ -134,6 +134,13 @@ public class PokeHandler {
             @Override
             public String get(final Pokemon p) {
                 final int length = 4;
+                return StringUtils.substring(PokeColumn.SPECIES.get(p).toString(), 0, length);
+            }
+        },
+        NAME_5("Pokémon Name (First five letters) [5]") {
+            @Override
+            public String get(final Pokemon p) {
+                final int length = 5;
                 return StringUtils.substring(PokeColumn.SPECIES.get(p).toString(), 0, length);
             }
         },
@@ -270,30 +277,30 @@ public class PokeHandler {
         MOVE_TYPE_1("Move 1 abbreviated (Ghost = Gh) [2]") {
             @Override
             public String get(final Pokemon p) {
-                final String type = PokemonMoveMetaRegistry.getMeta(p.getMove1()).getType().toString();
-                final boolean hasStab = type.equals(p.getMeta().getType1().toString()) || type.equals(p.getMeta().getType2().toString());
+                final String type = PokemonUtils.getMoveSettings(p.getMove1()).getPokemonType().toString();
+                final boolean hasStab = type.equals(PokemonUtils.getSettings(p).getType().toString()) || type.equals(PokemonUtils.getSettings(p).getType2().toString());
                 return hasStab ? abbreviateType(type).toUpperCase() : abbreviateType(type).toLowerCase();
             }
         },
         MOVE_TYPE_2("Move 2 abbreviated (Ghost = Gh) [2]") {
             @Override
             public String get(final Pokemon p) {
-                final String type = PokemonMoveMetaRegistry.getMeta(p.getMove2()).getType().toString();
-                final boolean hasStab = type.equals(p.getMeta().getType1().toString()) || type.equals(p.getMeta().getType2().toString());
+                final String type = PokemonUtils.getMoveSettings(p.getMove2()).getPokemonType().toString();
+                final boolean hasStab = type.equals(PokemonUtils.getSettings(p).getType().toString()) || type.equals(PokemonUtils.getSettings(p).getType2().toString());
                 return hasStab ? abbreviateType(type).toUpperCase() : abbreviateType(type).toLowerCase();
             }
         },
         MOVE_TYPE_1_UNI("Move 1 abbreviated (Eletric = ⚡) [1]") {
             @Override
             public String get(final Pokemon p) {
-                final String type = PokemonMoveMetaRegistry.getMeta(p.getMove1()).getType().toString();
+                final String type = PokemonUtils.getMoveSettings(p.getMove1()).getPokemonType().toString();
                 return UnicodeHelper.get(type);
             }
         },
         MOVE_TYPE_2_UNI("Move 2 abbreviated (Eletric = ⚡) [1]") {
             @Override
             public String get(final Pokemon p) {
-                final String type = PokemonMoveMetaRegistry.getMeta(p.getMove2()).getType().toString();
+                final String type = PokemonUtils.getMoveSettings(p.getMove2()).getPokemonType().toString();
                 return UnicodeHelper.get(type);
             }
         },
@@ -324,28 +331,28 @@ public class PokeHandler {
         TYPE_1("Pokémon Type 1 abbreviated (Ghost = Gh) [2]") {
             @Override
             public String get(final Pokemon p) {
-                final String type = p.getMeta().getType1().toString();
+                final String type = PokemonUtils.getMoveSettings(p.getMove1()).getPokemonType().toString();
                 return abbreviateType(type);
             }
         },
         TYPE_2("Pokémon Type 2 abbreviated (Ghost = Gh) [2]") {
             @Override
             public String get(final Pokemon p) {
-                final String type = p.getMeta().getType2().toString();
+                final String type = PokemonUtils.getMoveSettings(p.getMove2()).getPokemonType().toString();
                 return abbreviateType(type);
             }
         },
         TYPE_1_UNI("Pokémon Type 1 Unicode (Eletric = ⚡) [1]") {
             @Override
             public String get(final Pokemon p) {
-                final String type = p.getMeta().getType1().toString();
+                final String type = PokemonUtils.getMoveSettings(p.getMove1()).getPokemonType().toString();
                 return UnicodeHelper.get(type);
             }
         },
         TYPE_2_UNI("Pokémon Type 2 Unicode (Eletric = ⚡) [1]") {
             @Override
             public String get(final Pokemon p) {
-                final String type = p.getMeta().getType2().toString();
+                final String type = PokemonUtils.getMoveSettings(p.getMove2()).getPokemonType().toString();
                 return UnicodeHelper.get(type);
             }
         },

--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokemonPerformanceCache.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokemonPerformanceCache.java
@@ -3,11 +3,11 @@ package me.corriekay.pokegoutil.utils.pokemon;
 import java.util.EnumMap;
 import java.util.Map;
 
-import com.pokegoapi.api.pokemon.PokemonMeta;
-import com.pokegoapi.api.pokemon.PokemonMetaRegistry;
+import com.pokegoapi.main.PokemonMeta;
 
 import POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
 import POGOProtos.Enums.PokemonMoveOuterClass.PokemonMove;
+import POGOProtos.Settings.Master.PokemonSettingsOuterClass;
 
 /**
  * A Cache class which calculates and saves several values for Pokémon to make them easily available.
@@ -26,15 +26,15 @@ public final class PokemonPerformanceCache {
         PokemonPerformance<Double> globalHighestGymOffense = PokemonPerformance.DEFAULT_DOUBLE;
         PokemonPerformance<Long> globalHighestGymDefense = PokemonPerformance.DEFAULT_LONG;
 
-        for (final Map.Entry<PokemonId, PokemonMeta> entry : PokemonMetaRegistry.getMeta().entrySet()) {
+        for (final Map.Entry<PokemonId, PokemonSettingsOuterClass.PokemonSettings> entry : PokemonMeta.pokemonSettings.entrySet()) {
             final PokemonId pokemonId = entry.getKey();
-            final PokemonMeta meta = entry.getValue();
+            final PokemonSettingsOuterClass.PokemonSettings settings = entry.getValue();
 
             PokemonPerformance<Long> highestDuelAbility = PokemonPerformance.DEFAULT_LONG;
             PokemonPerformance<Double> highestGymOffense = PokemonPerformance.DEFAULT_DOUBLE;
             PokemonPerformance<Long> highestGymDefense = PokemonPerformance.DEFAULT_LONG;
-            for (final PokemonMove move1 : meta.getQuickMoves()) {
-                for (final PokemonMove move2 : meta.getCinematicMoves()) {
+            for (final PokemonMove move1 : settings.getQuickMovesList()) {
+                for (final PokemonMove move2 : settings.getCinematicMovesList()) {
                     final long duelAbility = PokemonCalculationUtils.duelAbility(pokemonId, move1, move2, PokemonUtils.MAX_IV, PokemonUtils.MAX_IV, PokemonUtils.MAX_IV);
                     if (duelAbility > highestDuelAbility.value) {
                         highestDuelAbility = new PokemonPerformance<>(pokemonId, duelAbility, move1, move2);

--- a/src/me/corriekay/pokegoutil/utils/pokemon/PokemonUtils.java
+++ b/src/me/corriekay/pokegoutil/utils/pokemon/PokemonUtils.java
@@ -9,20 +9,20 @@ import org.apache.commons.lang3.text.WordUtils;
 
 import com.pokegoapi.api.player.Team;
 import com.pokegoapi.api.pokemon.Pokemon;
-import com.pokegoapi.api.pokemon.PokemonMeta;
-import com.pokegoapi.api.pokemon.PokemonMetaRegistry;
-import com.pokegoapi.api.pokemon.PokemonMoveMeta;
-import com.pokegoapi.api.pokemon.PokemonMoveMetaRegistry;
-import com.pokegoapi.api.pokemon.PokemonType;
+import com.pokegoapi.main.PokemonMeta;
 import com.pokegoapi.util.PokeDictionary;
 
 import me.corriekay.pokegoutil.utils.ConfigKey;
 import me.corriekay.pokegoutil.utils.ConfigNew;
 import me.corriekay.pokegoutil.utils.StringLiterals;
 
+import POGOProtos.Enums.PokemonIdOuterClass;
 import POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
 import POGOProtos.Enums.PokemonMoveOuterClass.PokemonMove;
+import POGOProtos.Enums.PokemonTypeOuterClass;
 import POGOProtos.Inventory.Item.ItemIdOuterClass.ItemId;
+import POGOProtos.Settings.Master.MoveSettingsOuterClass;
+import POGOProtos.Settings.Master.PokemonSettingsOuterClass;
 
 /**
  * General Pokemon helper functions.
@@ -99,7 +99,7 @@ public final class PokemonUtils {
      * @param pokemonType The Pokémon Type.
      * @return Pokémon Type String.
      */
-    public static String formatType(final PokemonType pokemonType) {
+    public static String formatType(final PokemonTypeOuterClass.PokemonType pokemonType) {
         return StringUtils.capitalize(pokemonType.toString().toLowerCase().replaceAll("none", ""));
     }
 
@@ -152,9 +152,21 @@ public final class PokemonUtils {
      * @return Weather or not the Pokémon has STAB.
      */
     public static boolean hasStab(final PokemonId pokemonId, final PokemonMove move) {
-        final PokemonMeta meta = PokemonMetaRegistry.getMeta(pokemonId);
-        final PokemonMoveMeta moveMeta = PokemonMoveMetaRegistry.getMeta(move);
-        return meta.getType1().equals(moveMeta.getType()) || meta.getType2().equals(moveMeta.getType());
+        final PokemonSettingsOuterClass.PokemonSettings settings = getSettings(pokemonId);
+        final MoveSettingsOuterClass.MoveSettings moveSettings = getMoveSettings(move);
+        return settings.getType().equals(moveSettings.getPokemonType()) || settings.getType2().equals(moveSettings.getPokemonType());
+    }
+
+    public static PokemonSettingsOuterClass.PokemonSettings getSettings(Pokemon pokemon) {
+        return getSettings(pokemon.getPokemonId());
+    }
+
+    public static PokemonSettingsOuterClass.PokemonSettings getSettings(PokemonIdOuterClass.PokemonId pokemonId) {
+        return PokemonMeta.getPokemonSettings(pokemonId);
+    }
+
+    public static MoveSettingsOuterClass.MoveSettings getMoveSettings(PokemonMove pokemonMove) {
+        return PokemonMeta.getMoveSettings(pokemonMove);
     }
 }
 

--- a/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
+++ b/src/me/corriekay/pokegoutil/utils/windows/PokemonTableModel.java
@@ -41,18 +41,16 @@ public class PokemonTableModel extends AbstractTableModel {
 
         final MutableInt i = new MutableInt();
 
-        pokes.stream()
-            .filter(p -> p.getPokemonId().getNumber() <= PokemonId.MEW_VALUE)
-            .forEach(p -> {
-                pokeCol.add(i.getValue(), p);
+        pokes.forEach(p -> {
+            pokeCol.add(i.getValue(), p);
 
-                for (final PokeColumn column : PokeColumn.values()) {
-                    // Now lets add the value for that column
-                    column.data.add(i.getValue(), column.get(p));
-                }
+            for (final PokeColumn column : PokeColumn.values()) {
+                // Now lets add the value for that column
+                column.data.add(i.getValue(), column.get(p));
+            }
 
-                i.increment();
-            });
+            i.increment();
+        });
 
         fireTableDataChanged();
     }


### PR DESCRIPTION
This PR is to bump the PokeGOAPI-Java dependency to the latest version in order to get get2 pokemon added in.

Couple of issues that still needs to be addressed:
- The descriptor for the pokemon types doesn't seem to work. This appears to be an issue with the proto that PokeGOAPI-Java depends on.
<img width="1323" alt="screen shot 2017-02-17 at 11 45 01 am" src="https://cloud.githubusercontent.com/assets/1407078/23080689/8e7f11e8-f506-11e6-87ee-98eb694d43c4.png">

- There's an async issue where the list is getting refreshed before the inventory update is complete. As a temporary workaround, I added a 1 second sleep.

